### PR TITLE
Added enable script to intera_interface

### DIFF
--- a/intera_interface/scripts/enable_robot.py
+++ b/intera_interface/scripts/enable_robot.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python2
+
+# Copyright (c) 2013-2016, Rethink Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the Rethink Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import sys
+
+import rospy
+
+import intera_interface
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--state', const='state',
+                        dest='actions', action='append_const',
+                        help='Print current robot state')
+    parser.add_argument('-e', '--enable', const='enable',
+                        dest='actions', action='append_const',
+                        help='Enable the robot')
+    parser.add_argument('-d', '--disable', const='disable',
+                        dest='actions', action='append_const',
+                        help='Disable the robot')
+    parser.add_argument('-r', '--reset', const='reset',
+                        dest='actions', action='append_const',
+                        help='Reset the robot')
+    parser.add_argument('-S', '--stop', const='stop',
+                        dest='actions', action='append_const',
+                        help='Stop the robot')
+    args = parser.parse_args(rospy.myargv()[1:])
+
+    if args.actions == None:
+        parser.print_usage()
+        parser.exit(0, "No action defined")
+
+    rospy.init_node('sdk_robot_enable')
+    rs = intera_interface.RobotEnable(intera_interface.CHECK_VERSION)
+
+    try:
+        for act in args.actions:
+            if act == 'state':
+                print rs.state()
+            elif act == 'enable':
+                rs.enable()
+            elif act == 'disable':
+                rs.disable()
+            elif act == 'reset':
+                rs.reset()
+            elif act == 'stop':
+                rs.stop()
+    except Exception, e:
+        rospy.logerr(e.strerror)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
As a followup to #6, this script makes it easy to enable / disable / reset the robot from the command prompt using

```
$ rosrun intera_interface enable_robot.py -e
```

Or any of the other options. Tested on the real robot.
