### PR TITLE
Remove require nullspace goal in IK example

### DIFF
--- a/intera_examples/scripts/ik_service_client.py
+++ b/intera_examples/scripts/ik_service_client.py
@@ -73,10 +73,6 @@ def ik_test(limb = "right"):
     }
     # Add desired pose for inverse kinematics
     ikreq.pose_stamp.append(poses[limb])
-    # Avoid requiring nullspace goal
-    ikreq.use_nullspace_goal.append(False)
-    # Specify empty nullspace goal (as we are not using it anyway)
-    ikreq.nullspace_goal.append(JointState())
     # Request inverse kinematics from base to "right_hand" link
     ikreq.tip_names.append('right_hand')
 


### PR DESCRIPTION
With the update of the internal IK service to accept empty field for nullspace goals, we should be able to remove use_nullspace_goal and nullspace_goal in ik_service_client.py example
