### PR TITLE
Fix bug: shouldn't close camera on exit #27

### DIFF
--- a/intera_examples/scripts/camera_display.py
+++ b/intera_examples/scripts/camera_display.py
@@ -96,7 +96,6 @@ def main():
 
     def clean_shutdown():
         print("Shutting down camera_display node.")
-        camera.stop_streaming(args.camera)
         cv2.destroyAllWindows()
 
     rospy.on_shutdown(clean_shutdown)


### PR DESCRIPTION
Fix bug: Camera Example shouldn't close camera on exit
https://github.com/RethinkRobotics/intera_sdk/issues/27
Remove the line stop camera streaming fix the issue.
