### PR TITLE
No need to setup holding force, use default value

### DIFF
--- a/intera_examples/src/intera_examples/recorder.py
+++ b/intera_examples/src/intera_examples/recorder.py
@@ -55,7 +55,6 @@ class JointRecorder(object):
 
         # Verify Gripper Have No Errors and are Calibrated
         if self.has_gripper:
-            self._gripper.set_holding_force(0.0)
             if self._gripper.has_error():
                 self._gripper.reboot()                
             if not self._gripper.is_calibrated():

--- a/intera_interface/src/intera_interface/gripper.py
+++ b/intera_interface/src/intera_interface/gripper.py
@@ -39,7 +39,7 @@ class Gripper(object):
     MIN_POSITION = 0.0
     MAX_FORCE = 10.0
     MIN_FORCE = 0.0
-    MAX_VELOCITY = 0.3
+    MAX_VELOCITY = 3.0
     MIN_VELOCITY = 0.15
 
     def __init__(self, side="right"):


### PR DESCRIPTION
After change the gripper to another one, the inconsistancy issue not exist. 
So we do not need to setup holding force, the default value should be good.
The default speed for gripper is OK too. Won't affect gripper performance.
