### PR TITLE
Checks initial point for jumps in JTAS

### DIFF
--- a/intera_interface/cfg/SawyerPositionFFJointTrajectoryActionServer.cfg
+++ b/intera_interface/cfg/SawyerPositionFFJointTrajectoryActionServer.cfg
@@ -52,9 +52,9 @@ msg = (
     " - maximum final error",
     " - maximum error during trajectory execution",
     )
-min = (-1.0, -1.0,)
-default = (-1.0, 0.15,)
-max = (1.0, 1.0,)
+min = (-0.5, -0.5,)
+default = (-0.1, 0.1,)
+max = (0.5, 0.5,)
 
 for idx, param in enumerate(params):
     for joint in joints:


### PR DESCRIPTION
We need to check that the initial joint positions requested in the
trajectory requested is within the typical joint path thresholds,
in order to preven a faster-than-expected jump in the first JTAS
move.

A recent commit in MoveIt prevents this as well, setting a threshold
for aborting execution due to current joint angles.

Additionally, this commit tightens the default joint path error to
0.1 rad in the config
