### PR TITLE
Added absolute joint checking for JTAS init state

### DIFF
--- a/intera_interface/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/intera_interface/src/joint_trajectory_action/joint_trajectory_action.py
@@ -370,7 +370,7 @@ class JointTrajectoryActionServer(object):
         rospy.logdebug("Trajectory Points: {0}".format(trajectory_points))
         for jnt_name, jnt_value in self._get_current_error(
                 joint_names, trajectory_points[0].positions):
-            if self._path_thresh[jnt_name] < jnt_value:
+            if abs(self._path_thresh[jnt_name]) < abs(jnt_value):
                 rospy.logerr(("{0}: Initial Trajectory point violates "
                              "threshold on joint {1} with delta {2} radians. "
                              "Aborting trajectory execution.").format(


### PR DESCRIPTION
Fixes a bug where the initial state of joints
was missing an absolute value wrapper when checking
against the initial commanded value of the a
trajectory in the JTAS. Tested on real robot hardware.
