### PR TITLE
Updated joint_torque_springs for Intera SDK

### DIFF
--- a/intera_examples/CMakeLists.txt
+++ b/intera_examples/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin
 catkin_python_setup()
 
 generate_dynamic_reconfigure_options(
-  cfg/JointSpringsExample.cfg
+  cfg/SawyerJointSpringsExample.cfg
 )
 
 catkin_package(

--- a/intera_examples/cfg/SawyerJointSpringsExample.cfg
+++ b/intera_examples/cfg/SawyerJointSpringsExample.cfg
@@ -34,7 +34,7 @@ from dynamic_reconfigure.parameter_generator_catkin import (
 
 gen = ParameterGenerator()
 
-joints = ('right_j0', 'right_j1', 'right_j2', 'right_j3', 'right_j4', 'right_j5', 'right_j6')
+joints = ('j0', 'j1', 'j2', 'j3', 'j4', 'j5', 'j6')
 
 msg = (" - Joint spring stiffness (k). Hooke's Law.",
        " - Joint damping coefficient (c).")
@@ -54,4 +54,4 @@ for idx, joint in enumerate(joints):
         default_damping[idx], min, max_damping[idx]
         )
 
-exit(gen.generate('joint_torque', '', 'JointSpringsExample'))
+exit(gen.generate('joint_torque', '', 'SawyerJointSpringsExample'))


### PR DESCRIPTION
This update makes the example more robot-agnostic,
allowing the user to attach to a robot and query
the param server to obtain the proper name of the
robot, and its capable limbs, before launching
the example.