### PR TITLE
Updates tolerance for fast JTAS moves

### DIFF
--- a/intera_interface/cfg/SawyerPositionFFJointTrajectoryActionServer.cfg
+++ b/intera_interface/cfg/SawyerPositionFFJointTrajectoryActionServer.cfg
@@ -53,7 +53,7 @@ msg = (
     " - maximum error during trajectory execution",
     )
 min = (-0.5, -0.5,)
-default = (-0.1, 0.1,)
+default = (-0.2, 0.2,)
 max = (0.5, 0.5,)
 
 for idx, param in enumerate(params):


### PR DESCRIPTION
This update allows for greater tolerance during JTAS moves. If a user is receiving trajectory preemption falsely, increase this value. A low a value as possible without preemption is desired.