### PR TITLE
Added intera_interface Lights and lights_blink ex

### DIFF
--- a/intera_examples/scripts/lights_blink.py
+++ b/intera_examples/scripts/lights_blink.py
@@ -31,67 +31,62 @@ import argparse
 
 import rospy
 
-import intera_interface.digital_io as DIO
+from intera_interface import Lights
 
 
-def test_interface(io_component='left_outer_light'):
-    """Blinks a Digital Output on then off."""
-    rospy.loginfo("Blinking Digital Output: %s", io_component)
-    b = DIO.DigitalIO(io_component)
-
-    print "Initial state: ", b.state
-
+def test_light_interface(light_name='head_green_light'):
+    """Blinks a desired Light on then off."""
+    l = Lights()
+    rospy.loginfo("All available lights on this robot:\n{0}\n".format(
+                                               ', '.join(l.list_all_lights())))
+    rospy.loginfo("Blinking Light: {0}".format(light_name))
+    on_off = lambda x: 'ON' if l.get_light_state(x) else 'OFF'
+    rospy.loginfo("Initial state: {0}".format(on_off(light_name)))
     # turn on light
-    b.set_output(True)
+    l.set_light_state(light_name, True)
     rospy.sleep(1)
-    print "New state: ", b.state
-
+    rospy.loginfo("New state: {0}".format(on_off(light_name)))
+    # turn off light
+    l.set_light_state(light_name, False)
+    rospy.sleep(1)
+    rospy.loginfo("New state: {0}".format(on_off(light_name)))
+    # turn on light
+    l.set_light_state(light_name, True)
+    rospy.sleep(1)
+    rospy.loginfo("New state: {0}".format(on_off(light_name)))
     # reset output
-    b.set_output(False)
+    l.set_light_state(light_name, False)
     rospy.sleep(1)
-    print "Final state:", b.state
+    rospy.loginfo("Final state: {0}".format(on_off(light_name)))
 
 
 def main():
-    """RSDK Digital IO Example: Blink
+    """Intera SDK Lights Example: Blink
 
-    Turns the output of a DigitalIO component on then off again
+    Toggles the Lights interface on then off again
     while printing the state at each step. Simple demonstration
-    of using the intera_interface.DigitalIO class.
+    of using the intera_interface.Lights class.
 
-    Run this example with default arguments and watch the light
-    on the left arm Navigator blink on and off while the console
-    echos the state. Use the component_id argument or ROS Parameter
-    to change the DigitalIO component used.
+    Run this example with default arguments and watch the green
+    light on the head blink on and off while the console
+    echos the state. Use the light names from Lights.list_all_lights()
+    to change lights to toggle.
     """
-    epilog = """
-ROS Parameters:
-  ~component_id        - name of DigitalIO component to use
-
-Baxter DigitalIO
-    Note that 'DigitalIO' components are only those that use
-    the custom ROS Messages intera_core_msgs/DigitalIOState
-    and intera_core_msgs/DigitalOutputCommand.
-
-    Component names can be found on the Wiki, or by echoing
-    the names field of the digital_io_states topic:
-      $ rostopic echo -n 1 /robot/digital_io_states/names
-    """
+    epilog = """ Intera Interface Lights """
     arg_fmt = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(formatter_class=arg_fmt,
                                      description=main.__doc__,
                                      epilog=epilog)
     parser.add_argument(
-        '-c', '--component', dest='component_id',
-        default='left_outer_light',
-        help=('name of Digital IO component to use'
-              ' (default: left_outer_light)')
+        '-l', '--light_name', dest='light_name',
+        default='head_green_light',
+        help=('name of Light component to use'
+              ' (default: head_green_light)')
     )
     args = parser.parse_args(rospy.myargv()[1:])
 
-    rospy.init_node('rsdk_digital_io_blink', anonymous=True)
-    io_component = rospy.get_param('~component_id', args.component_id)
-    test_interface(io_component)
+    rospy.init_node('sdk_lights_blink', anonymous=True)
+    test_light_interface(args.light_name)
 
 if __name__ == '__main__':
     main()

--- a/intera_interface/src/intera_interface/__init__.py
+++ b/intera_interface/src/intera_interface/__init__.py
@@ -31,6 +31,7 @@ from .gripper import Gripper
 from .cuff import Cuff
 from .head import Head
 from .head_display import HeadDisplay
+from .lights import Lights
 from .limb import Limb
 from .navigator import Navigator
 from .robot_enable import RobotEnable

--- a/intera_interface/src/intera_interface/lights.py
+++ b/intera_interface/src/intera_interface/lights.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2016, Rethink Robotics
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the Rethink Robotics nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+from io_interface import IODeviceInterface
+
+
+class Lights(object):
+    """
+    Interface class for the lights on the Intera robots.
+    """
+
+    def __init__(self):
+        """
+        Constructor.
+
+        """
+        self._lights_io = IODeviceInterface("robot", "robot")
+
+    def list_all_lights(self):
+        """
+        Returns a list of strings describing all available lights
+
+        @rtype: list
+        @return: a list of string representing light names
+                 Each light name of the following format:
+                 '<assembly>_<color>_light'
+        """
+        return [name for name in self._lights_io.list_signal_names() if "light" in name]
+
+    def set_light_state(self, name, on=True):
+        """
+        Sets the named light the desired state (on=True, off=False)
+
+        @type name: str
+        @param name: Light name of the following format:
+                     '<assembly>_<color>_light'
+        @type on: bool
+        @param on: value to set the light (on=True, off=False)
+        """
+        self._lights_io.set_signal_value(name, on)
+
+    def get_light_state(self, name):
+        """
+        Returns a boolean describing whether the requested light is 'ON'.
+        (True: on, False: off)
+
+        @type name: str
+        @param name: Light name of the following format:
+                     '<assembly>_<color>_light'
+        @rtype: bool
+        @return:  a variable representing light state: (True: on, False: off)
+        """
+        return self._lights_io.get_signal_value(name)
+

--- a/intera_interface/src/intera_interface/limb.py
+++ b/intera_interface/src/intera_interface/limb.py
@@ -46,7 +46,7 @@ from intera_core_msgs.msg import (
     EndpointState,
     CollisionDetectionState,
 )
-from intera_interface import settings
+import settings
 from robot_params import RobotParams
 
 

--- a/intera_interface/src/intera_interface/robot_enable.py
+++ b/intera_interface/src/intera_interface/robot_enable.py
@@ -43,7 +43,7 @@ import intera_dataflow
 from intera_core_msgs.msg import (
     AssemblyState,
 )
-from intera_interface import settings
+import settings
 
 
 class RobotEnable(object):


### PR DESCRIPTION
This commit adds the `intera_interface.Lights` class
for setting and getting the internal state of each
light available on an intera robot. These lights
are individually controlable by color channel, but
are only "boolean" in nature. You can set a Blue
light OFF or ON, but not in between. All lights
and light colors are individually controlable.

- Adds `intera_interface/src/intera_interface/lights.py`
- Adds `intera_examples/scripts/lights_blink.py`

Reworked the settings import for some `intera_interface`
classes to be compatible with python 2.7.12

Resolves #52 