### PR TITLE
Re #70 Fixes Joint Position Joystick example

### DIFF
--- a/intera_examples/launch/joint_position_joystick.launch
+++ b/intera_examples/launch/joint_position_joystick.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- Joystick Type Argument: {xbox, ps3, logitech} -->
-  <arg name="joystick" />
+  <arg name="joystick" default="xbox"/>
 
   <!-- Joystick Device Argument-->
   <arg name="dev" default="/dev/input/js0" />

--- a/intera_examples/package.xml
+++ b/intera_examples/package.xml
@@ -40,5 +40,6 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>intera_core_msgs</run_depend>
   <run_depend>intera_interface</run_depend>
+  <run_depend>joystick_drivers</run_depend>
 
 </package>


### PR DESCRIPTION
This resolves the issue where the commands were printed
out too often, and any movement of the joystick would cause
the program to exit. Additionally, *both* joysticks will
cause joints to move (one joint per axis, 4 total), and
rotation will operate the same - just with four joints.

Tested against the current SDK onboard a robot.