### PR TITLE
Fix init gripper calibration setting

### DIFF
--- a/intera_interface/src/intera_interface/gripper.py
+++ b/intera_interface/src/intera_interface/gripper.py
@@ -64,7 +64,7 @@ class Gripper(object):
         if self.has_error():
             self.reboot()
             calibrate = True
-        if calibrate and self.is_calibrated():
+        if calibrate and not self.is_calibrated():
             self.calibrate()
 
     def _config_callback(self, msg):


### PR DESCRIPTION
Quick fix to avoid gripper calibration when the gripper already calibrated.
The logic now updated to : execute calibrate function if we want the gripper to be calibrated and the gripper is not calibrated yet.
