### PR TITLE
Ensure robot is in Stop State before Reset

### DIFF
--- a/intera_examples/scripts/gripper_joystick.py
+++ b/intera_examples/scripts/gripper_joystick.py
@@ -39,12 +39,10 @@ def map_joystick(joystick, limb):
     except ValueError:
         rospy.logerr("Could not detect a gripper attached to the robot.")
         return
-    
+
     def clean_shutdown():
         print("\nExiting example...")
-        if not init_state:
-            print("Disabling robot...")
-            rs.disable()
+
     rospy.on_shutdown(clean_shutdown)
 
     # decrease position dead_zone

--- a/intera_examples/scripts/gripper_keyboard.py
+++ b/intera_examples/scripts/gripper_keyboard.py
@@ -36,9 +36,6 @@ def map_keyboard(limb):
         rospy.logerr("Could not detect a gripper attached to the robot.")
         return
     def clean_shutdown():
-        if not init_state:
-            print("Disabling robot...")
-            rs.disable()
         print("Exiting example.")
     rospy.on_shutdown(clean_shutdown)
     def offset_position(offset):

--- a/intera_examples/scripts/head_wobbler.py
+++ b/intera_examples/scripts/head_wobbler.py
@@ -49,9 +49,6 @@ class Wobbler(object):
         print("\nExiting example...")
         if self._done:
             self.set_neutral()
-        if not self._init_state and self._rs.state().enabled:
-            print("Disabling robot...")
-            self._rs.disable()
 
     def set_neutral(self):
         """

--- a/intera_examples/scripts/joint_position_file_playback.py
+++ b/intera_examples/scripts/joint_position_file_playback.py
@@ -163,9 +163,7 @@ Related examples:
 
     def clean_shutdown():
         print("\nExiting example...")
-        if not init_state:
-            print("Disabling robot...")
-            rs.disable()
+
     rospy.on_shutdown(clean_shutdown)
 
     print("Enabling robot... ")

--- a/intera_examples/scripts/joint_position_joystick.py
+++ b/intera_examples/scripts/joint_position_joystick.py
@@ -203,9 +203,7 @@ key bindings.
 
     def clean_shutdown():
         print("\nExiting example.")
-        if not init_state:
-            print("Disabling robot...")
-            rs.disable()
+
     rospy.on_shutdown(clean_shutdown)
 
     rospy.loginfo("Enabling robot...")

--- a/intera_examples/scripts/joint_position_keyboard.py
+++ b/intera_examples/scripts/joint_position_keyboard.py
@@ -29,7 +29,7 @@ from intera_interface import CHECK_VERSION
 
 def map_keyboard(side):
     limb = intera_interface.Limb(side)
-    
+
     try:
         gripper = intera_interface.Gripper(side)
     except:
@@ -136,9 +136,7 @@ See help inside the example with the '?' key for key bindings.
 
     def clean_shutdown():
         print("\nExiting example.")
-        if not init_state:
-            print("Disabling robot...")
-            rs.disable()
+
     rospy.on_shutdown(clean_shutdown)
 
     rospy.loginfo("Enabling robot...")

--- a/intera_examples/scripts/joint_position_waypoints.py
+++ b/intera_examples/scripts/joint_position_waypoints.py
@@ -130,9 +130,6 @@ class Waypoints(object):
 
     def clean_shutdown(self):
         print("\nExiting example...")
-        if not self._init_state:
-            print("Disabling robot...")
-            self._rs.disable()
         return True
 
 

--- a/intera_examples/scripts/joint_torque_springs.py
+++ b/intera_examples/scripts/joint_torque_springs.py
@@ -117,7 +117,7 @@ class JointSprings(object):
 
         # for safety purposes, set the control rate command timeout.
         # if the specified number of command cycles are missed, the robot
-        # will timeout and disable
+        # will timeout and return to Position Control Mode
         self._limb.set_command_timeout((1.0 / self._rate) * self._missed_cmds)
 
         # loop at specified rate commanding new joint torques
@@ -135,9 +135,6 @@ class JointSprings(object):
         """
         print("\nExiting example...")
         self._limb.exit_control_mode()
-        if not self._init_state and self._rs.state().enabled:
-            print("Disabling robot...")
-            self._rs.disable()
 
 
 def main():

--- a/intera_examples/scripts/joint_velocity_wobbler.py
+++ b/intera_examples/scripts/joint_velocity_wobbler.py
@@ -74,9 +74,6 @@ class Wobbler(object):
         #return to normal
         self._reset_control_modes()
         self.set_neutral()
-        if not self._init_state:
-            print("Disabling robot...")
-            self._rs.disable()
         return True
 
     def wobble(self):


### PR DESCRIPTION
Resetting the robot's state is only valid if the robot is currently in a Stopped (ERROR) state. This command is actually underlying the Enable / Disabled states, and should be used with caution. Enable & Disable are the preferred methods for stopping the robot.

Additionally, this commit removes unnecessary Disable after examples. In many Baxter examples, it made sense to disable the robot after each example, if the robot was disabled to begin with. On Sawyer, this workflow makes less sense, as the robot is nearly always enabled unless there is an Error or E-Stop. For this reason, the Disabling is removed from the examples.