### PR TITLE
Add JointLimits interface and send_random_trajectory script

### DIFF
--- a/intera_examples/scripts/go_to_joint_angles_in_contact.py
+++ b/intera_examples/scripts/go_to_joint_angles_in_contact.py
@@ -58,6 +58,11 @@ def main():
     -q -0.2 0.1 0.1 0.2 -0.3 0.2 0.4 -s 0.9 -a 0.1
     --> Go to pose [...] witha speed ratio of 0.9 and an accel ratio of 0.1
 
+    --trajType CARTESIAN
+    --> Use a Cartesian interpolated endpoint path to reach the goal
+
+    === Interaction Mode options ===
+
     -st 1
     --> Set the interaction controller state (1 for True, 0 for False) in the current configuration
 

--- a/intera_examples/scripts/send_random_trajectory.py
+++ b/intera_examples/scripts/send_random_trajectory.py
@@ -1,0 +1,176 @@
+#! /usr/bin/env python
+
+# Copyright (c) 2016-2017, Rethink Robotics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rospy
+import motion_msgs.msg
+import argparse
+from intera_motion_interface import (
+    MotionTrajectory,
+    MotionWaypoint,
+    MotionWaypointOptions,
+    RandomWalk
+)
+from motion_msgs.msg import TrajectoryOptions
+from intera_core_msgs.msg import JointLimits
+from intera_interface import (
+    Limb,
+    JointLimits
+)
+
+def main():
+    """
+    Send a random-walk trajectory, starting from the current pose of the robot.
+    Can be used to send both joint and cartesian trajectories.
+
+    Call using:
+    $ rosrun intera_examples send_random_trajectory.py  [arguments: see below]
+
+    -n 5 -t JOINT -s 0.5
+    --> Send a trandom joint trajectory with 5 waypoints, using a speed ratio
+        of 0.5 for all waypoints. Use default random walk settings.
+
+    -d 0.1 -b 0.2
+    --> Send a random trajectory with default trajectory settings. Use a
+        maximum step distance of 0.1*(upper joint limit - lower joint limit)
+        and avoid the upper and lower joint limits by a boundary of
+        0.2*(upper joint limit - lower joint limit).
+
+    --trajArch CONSTRAINED_CLAMPED_CUBIC
+    --> Override the default trajectory architecture when generating the
+        KinematicTrajectory object in the motion controller. This feature
+        is included for testing new trajectory generation algorithms. In this
+        case, we override the default (set in motion_controller.cpp) and used
+        the CONSTRAINED_CLAMPED_CUBIC architecture instead.
+
+    -o ~/Desktop/fileName.bag
+    --> Save the trajectory message to a bag file
+
+    -p
+    --> Prints the trajectory to terminal before sending
+
+    """
+    arg_fmt = argparse.RawDescriptionHelpFormatter
+    parser = argparse.ArgumentParser(formatter_class=arg_fmt,
+                                     description=main.__doc__)
+    parser.add_argument(
+        "-n", "--waypoint_count", type=int, default=5,
+        help="number of waypoints to include in the trajectory")
+    parser.add_argument(
+        "-d", "--stepDistance", type=float, default=0.05,
+        help="normalized random walk step distance")
+    parser.add_argument(
+        "-b", "--boundaryPadding", type=float, default=0.1,
+        help="normalized padding to apply to joint limits")
+    parser.add_argument(
+        "-t", "--trajType", type=str, default='JOINT',
+        choices=['JOINT', 'CARTESIAN'],
+        help="trajectory interpolation type")
+    parser.add_argument(
+        "--trajArch", type=str, default='',
+        choices=['', 'DEFAULT', 'CONSTRAINED_COMPOSITE_CUBIC',
+                 'CONSTRAINED_BOUNDARY_CUBIC', 'CONSTRAINED_CLAMPED_CUBIC',
+                 'CLAMPED_CUBIC', 'CLAMPED_BOUNDARY_CUBIC'],
+        help="trajectory architecture")
+    parser.add_argument(
+        "-s",  "--speed_ratio", type=float, default=0.5,
+        help="A value between 0.0 (slow) and 1.0 (fast)")
+    parser.add_argument(
+        "-a",  "--accel_ratio", type=float, default=0.5,
+        help="A value between 0.0 (slow) and 1.0 (fast)")
+    parser.add_argument(
+        "-o", "--output_file",
+        help="Save the trajectory task to a bag file")
+    parser.add_argument(
+        "--output_file_type", default="yaml",
+        choices=["csv", "yaml"], help="Select the save file type")
+    parser.add_argument(
+        "-p", "--print_trajectory", action='store_true', default=False,
+        help="print the trajectory after loading")
+    parser.add_argument(
+        "--do_not_send", action='store_true', default=False,
+        help="generate the trajectory, but do not send to motion controller.")
+    parser.add_argument(
+        "--log_file_output",
+        help="Save motion controller log messages to this file name")
+    args = parser.parse_args()
+
+    if args.waypoint_count < 1:
+        args.waypoint_count = 1
+        rospy.logwarn('Input out of bounds! Setting waypoint_count = 1')
+
+    try:
+        rospy.init_node('send_random_joint_trajectory_py')
+
+        # Set the trajectory options
+        traj_opts = TrajectoryOptions()
+        traj_opts.trajectory_architecture_type = args.trajArch
+        traj_opts.interpolation_type = args.trajType
+        traj = MotionTrajectory(trajectory_options = traj_opts)
+
+        # Set the waypoint options
+        wpt_opts = MotionWaypointOptions(max_joint_speed_ratio=args.speed_ratio,
+                                        max_joint_accel=args.accel_ratio)
+        waypoint = MotionWaypoint(options = wpt_opts.to_msg())
+
+        # Append a waypoint at the current pose
+        limb = Limb()
+        waypoint.set_joint_angles(limb.joint_ordered_angles())
+        traj.append_waypoint(waypoint.to_msg())
+
+        # Set up the random walk generator
+        walk = RandomWalk()
+        limits = JointLimits()
+        walk.set_lower_limits(limits.get_joint_lower_limits(limb.joint_names()))
+        walk.set_upper_limits(limits.get_joint_upper_limits(limb.joint_names()))
+        walk.set_last_point(waypoint.get_joint_angles())
+        walk.set_boundary_padding(args.boundaryPadding)
+        walk.set_maximum_distance(args.stepDistance)
+
+        for i in range(0, args.waypoint_count):
+            joint_angles = walk.get_next_point()
+            waypoint.set_joint_angles(joint_angles = joint_angles)
+            traj.append_waypoint(waypoint.to_msg())
+
+        print traj.to_msg()
+
+        if args.output_file is not None:
+            if args.output_file_type == "csv":
+                traj.to_csv_file(args.output_file)
+            elif args.output_file_type == "yaml":
+                traj.to_yaml_file(args.output_file)
+            else:
+                rospy.logwarn("Did not recognize output file type")
+
+        if args.print_trajectory:
+            rospy.loginfo('\n' + traj.to_string())
+
+        if args.log_file_output is not None:
+            traj.set_log_file_name(args.log_file_output)
+
+        if not args.do_not_send:
+            result = traj.send_trajectory()
+            if result is not None and result.result:
+                rospy.loginfo('Motion controller %s',
+                              'successfully finished the trajectory!')
+            else:
+                rospy.loginfo('Motion controller %s',
+                              'failed to complete the trajectory!')
+    except rospy.ROSInterruptException:
+        rospy.logerr('Keyboard interrupt detected from the user. %s',
+                     'Exiting before trajectory completion.')
+
+if __name__ == '__main__':
+    main()

--- a/intera_examples/scripts/send_random_trajectory.py
+++ b/intera_examples/scripts/send_random_trajectory.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import rospy
 import argparse
 from intera_motion_interface import (
@@ -28,6 +29,9 @@ from intera_interface import (
     Limb,
     JointLimits
 )
+
+if (sys.version_info < (3, 0)):
+  input = raw_input
 
 def main():
     """
@@ -102,8 +106,13 @@ def main():
 
     try:
         rospy.init_node('send_random_joint_trajectory_py')
+
         rospy.logwarn('Make sure the surrounding area around the robot is '
                       'collision free prior to sending random trajectories.')
+        k = input("Press 'Enter' when the robot is clear to continue...")
+        if k:
+            rospy.logerr("Please press only the 'Enter' key to begin execution. Exiting...")
+            sys.exit(1)
 
         # Set the trajectory options
         traj_opts = TrajectoryOptions()

--- a/intera_examples/scripts/send_random_trajectory.py
+++ b/intera_examples/scripts/send_random_trajectory.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import rospy
-import motion_msgs.msg
 import argparse
 from intera_motion_interface import (
     MotionTrajectory,
@@ -34,6 +33,9 @@ def main():
     """
     Send a random-walk trajectory, starting from the current pose of the robot.
     Can be used to send both joint and cartesian trajectories.
+
+    WARNING: Make sure the surrounding area around the robot is collision free
+             prior to sending random trajectories.
 
     Call using:
     $ rosrun intera_examples send_random_trajectory.py  [arguments: see below]
@@ -100,6 +102,8 @@ def main():
 
     try:
         rospy.init_node('send_random_joint_trajectory_py')
+        rospy.logwarn('Make sure the surrounding area around the robot is '
+                      'collision free prior to sending random trajectories.')
 
         # Set the trajectory options
         traj_opts = TrajectoryOptions()

--- a/intera_examples/scripts/send_random_trajectory.py
+++ b/intera_examples/scripts/send_random_trajectory.py
@@ -48,13 +48,6 @@ def main():
         and avoid the upper and lower joint limits by a boundary of
         0.2*(upper joint limit - lower joint limit).
 
-    --trajArch CONSTRAINED_CLAMPED_CUBIC
-    --> Override the default trajectory architecture when generating the
-        KinematicTrajectory object in the motion controller. This feature
-        is included for testing new trajectory generation algorithms. In this
-        case, we override the default (set in motion_controller.cpp) and used
-        the CONSTRAINED_CLAMPED_CUBIC architecture instead.
-
     -o ~/Desktop/fileName.bag
     --> Save the trajectory message to a bag file
 
@@ -78,12 +71,6 @@ def main():
         "-t", "--trajType", type=str, default='JOINT',
         choices=['JOINT', 'CARTESIAN'],
         help="trajectory interpolation type")
-    parser.add_argument(
-        "--trajArch", type=str, default='',
-        choices=['', 'DEFAULT', 'CONSTRAINED_COMPOSITE_CUBIC',
-                 'CONSTRAINED_BOUNDARY_CUBIC', 'CONSTRAINED_CLAMPED_CUBIC',
-                 'CLAMPED_CUBIC', 'CLAMPED_BOUNDARY_CUBIC'],
-        help="trajectory architecture")
     parser.add_argument(
         "-s",  "--speed_ratio", type=float, default=0.5,
         help="A value between 0.0 (slow) and 1.0 (fast)")
@@ -116,7 +103,6 @@ def main():
 
         # Set the trajectory options
         traj_opts = TrajectoryOptions()
-        traj_opts.trajectory_architecture_type = args.trajArch
         traj_opts.interpolation_type = args.trajType
         traj = MotionTrajectory(trajectory_options = traj_opts)
 
@@ -143,8 +129,6 @@ def main():
             joint_angles = walk.get_next_point()
             waypoint.set_joint_angles(joint_angles = joint_angles)
             traj.append_waypoint(waypoint.to_msg())
-
-        print traj.to_msg()
 
         if args.output_file is not None:
             if args.output_file_type == "csv":

--- a/intera_interface/src/intera_interface/__init__.py
+++ b/intera_interface/src/intera_interface/__init__.py
@@ -18,6 +18,7 @@ from .gripper import Gripper
 from .cuff import Cuff
 from .head import Head
 from .head_display import HeadDisplay
+from .joint_limits import JointLimits
 from .lights import Lights
 from .limb import Limb
 from .navigator import Navigator

--- a/intera_interface/src/intera_interface/joint_limits.py
+++ b/intera_interface/src/intera_interface/joint_limits.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2017, Rethink Robotics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+import rospy
+from intera_core_msgs.msg import JointLimits as JointLimitsMsg
+import intera_dataflow
+
+class JointLimits(object):
+    """
+    Interface class for joint limits on Intera robots
+    """
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self._joint_position_lower = dict()
+        self._joint_position_upper = dict()
+        self._joint_velocity_limit = dict()
+        self._joint_accel_limit = dict()
+        self._joint_effort_limit = dict()
+        self._joint_names = list()
+
+        joint_limit_topic = '/robot/joint_limits'
+        _joint_limit_sub = rospy.Subscriber(
+            joint_limit_topic,
+            JointLimitsMsg,
+            self._on_joint_limits,
+            queue_size=1)
+
+        err_msg = ("%init failed to get current joint_limits "
+                   "from %s", joint_limit_topic)
+        intera_dataflow.wait_for(lambda: len(self._joint_names) > 0,
+                                 timeout_msg=err_msg, timeout=5.0)
+
+    def _on_joint_limits(self, msg):
+        self._joint_names = msg.joint_names
+        self._joint_position_lower.clear()
+        self._joint_position_upper.clear()
+        self._joint_velocity_limit.clear()
+        self._joint_accel_limit.clear()
+        self._joint_effort_limit.clear()
+        for idx, name in enumerate(msg.joint_names):
+            self._joint_position_lower[name] = msg.position_lower[idx]
+            self._joint_position_upper[name] = msg.position_upper[idx]
+            self._joint_velocity_limit[name] = msg.velocity[idx]
+            self._joint_accel_limit[name] = msg.accel[idx]
+            self._joint_effort_limit[name] = msg.effort[idx]
+
+    def joint_position_lower_limits(self):
+        """
+        Return the joint lower position limits  (radians)
+
+        @rtype: dict({str:float})
+        @return: unordered dict of joint lower position limits
+        """
+        return deepcopy(self._joint_position_lower)
+
+    def joint_position_upper_limits(self):
+        """
+        Return the joint upper position limits  (radians)
+
+        @rtype: dict({str:float})
+        @return: unordered dict of joint upper position limits
+        """
+        return deepcopy(self._joint_position_upper)
+
+    def joint_velocity_limits(self):
+        """
+        Return the joint velocity limits  (rad/s)
+
+        @rtype: dict({str:float})
+        @return: unordered dict of joint velcoity limits
+        """
+        return deepcopy(self._joint_velocity_limit)
+
+    def joint_acceleration_limits(self):
+        """
+        Return the joint acceleration limits  (rad/s/s)
+
+        @rtype: dict({str:float})
+        @return: unordered dict of joint accleration limits
+        """
+        return deepcopy(self._joint_accel_limit)
+
+    def joint_effort_limits(self):
+        """
+        Return the joint effort limits  (Nm)
+
+        @rtype: dict({str:float})
+        @return: unordered dict of joint effort limits
+        """
+        return deepcopy(self._joint_effort_limit)
+
+    def joint_lower_limit(self, joint):
+        """
+        Return the requested joint lower position limit
+
+        @type joint: str
+        @param joint: name of a joint
+        @rtype: float
+        @return: joint lower position limit  (radian)
+        """
+        return self._joint_position_lower[joint]
+
+    def joint_upper_limit(self, joint):
+        """
+        Return the requested joint upper position limit
+
+        @type joint: str
+        @param joint: name of a joint
+        @rtype: float
+        @return: joint upper position limit  (radian)
+        """
+        return self._joint_position_upper[joint]
+
+    def joint_velocity_limit(self, joint):
+        """
+        Return the requested joint velocity limit
+
+        @type joint: str
+        @param joint: name of a joint
+        @rtype: float
+        @return: joint velocity limit  (rad/s)
+        """
+        return self._joint_velocity_limit[joint]
+
+    def joint_acceleration_limit(self, joint):
+        """
+        Return the requested joint accleration limit
+
+        @type joint: str
+        @param joint: name of a joint
+        @rtype: float
+        @return: joint acceleration limit  (rad/s/s)
+        """
+        return self._joint_accel_limit[joint]
+
+    def joint_effort_limit(self, joint):
+        """
+        Return the requested joint effort limit
+
+        @type joint: str
+        @param joint: name of a joint
+        @rtype: float
+        @return: joint effort limit  (Nm)
+        """
+        return self._joint_effort_limit[joint]
+
+    def get_joint_lower_limits(self, joint_names):
+        """
+        Return the joint lower position limits  (radians)
+
+        @type joint_names: [str]
+        @param joint_names: list of joint names
+        @rtype: [float]
+        @return: ordered list of joint lower position limits
+        """
+        return [self._joint_position_lower[name] for name in joint_names]
+
+    def get_joint_upper_limits(self, joint_names):
+        """
+        Return the joint upper position limits  (radians)
+
+        @type joint_names: [str]
+        @param joint_names: list of joint names
+        @rtype: [float]
+        @return: ordered list of joint upper position limits
+        """
+        return [self._joint_position_upper[name] for name in joint_names]
+
+    def get_joint_velocity_limits(self, joint_names):
+        """
+        Return the joint velocity limits  (rad/s)
+
+        @type joint_names: [str]
+        @param joint_names: list of joint names
+        @rtype: [float]
+        @return: ordered list of joint velocity limits
+        """
+        return [self._joint_velocity_limit[name] for name in joint_names]
+
+    def get_joint_acceleration_limits(self, joint_names):
+        """
+        Return the joint acceleration limits  (rad/s/s)
+
+        @type joint_names: [str]
+        @param joint_names: list of joint names
+        @rtype: [float]
+        @return: ordered list of joint acceleration limits
+        """
+        return [self._joint_accel_limit[name] for name in joint_names]
+
+    def get_joint_effort_limits(self, joint_names):
+        """
+        Return the joint effort limits  (Nm)
+
+        @type joint_names: [str]
+        @param joint_names: list of joint names
+        @rtype: [float]
+        @return: ordered list of joint effort limits
+        """
+        return [self._joint_effort_limit[name] for name in joint_names]
+

--- a/intera_interface/src/intera_motion_interface/__init__.py
+++ b/intera_interface/src/intera_motion_interface/__init__.py
@@ -3,6 +3,7 @@ from .motion_trajectory import MotionTrajectory
 from .motion_waypoint import MotionWaypoint
 from .motion_waypoint_options import MotionWaypointOptions
 from .interaction_options import InteractionOptions
+from .random_walk import RandomWalk
 from .utility_functions import (
     clamp_float_warn,
     ensure_path_to_file_exists,

--- a/intera_interface/src/intera_motion_interface/motion_waypoint.py
+++ b/intera_interface/src/intera_motion_interface/motion_waypoint.py
@@ -69,9 +69,9 @@ class MotionWaypoint(object):
         """
         self._data = Waypoint()
 
+        self._limb = Limb()
         self.set_joint_angles(joint_angles, active_endpoint)
         self.set_waypoint_options(options)
-        self._limb = Limb()
 
     def set_from_message(self, wpt_msg):
         if isinstance(wpt_msg, Waypoint):

--- a/intera_interface/src/intera_motion_interface/random_walk.py
+++ b/intera_interface/src/intera_motion_interface/random_walk.py
@@ -1,0 +1,127 @@
+#! /usr/bin/env python
+
+# Copyright (c) 2016-2017, Rethink Robotics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from copy import deepcopy
+import random
+import rospy
+
+class RandomWalk(object):
+    """
+    This class is used to create a random walk in a bounded state space
+    """
+
+    def __init__(self):
+        """
+        Constructor - creates an empty random walk object. Be sure to set the
+        lower and upper limits, as well as the past point before calling.
+        """
+
+        self._lower_limit = None
+        self._upper_limit = None
+        self._last_point = None
+        self._dimension = None
+        self._boundary_padding = 0.0
+        self._maximum_distance = 1.0
+
+    def set_lower_limits(self, low):
+        if not self._check_dimension(low):
+            return False
+        self._lower_limit = deepcopy(low)
+        return True
+
+    def set_upper_limits(self, upp):
+        if not self._check_dimension(upp):
+            return False
+        self._upper_limit = deepcopy(upp)
+        return True
+
+    def set_last_point(self, val):
+        if not self._check_dimension(val):
+            return False
+        self._last_point = deepcopy(val)
+        return True
+
+    def set_boundary_padding(self, pad):
+        if pad < 0.0:
+            rospy.logwarn(' cannot set negative padding values')
+            pad = 0.0
+        elif pad > 0.499999:
+            rospy.logwarn(' cannot set padding values greater than 0.5')
+            pad = 0.499999
+        self._boundary_padding = pad
+
+    def set_maximum_distance(self, dist):
+        if dist < 0.00001:
+            rospy.logwarn(' distance must be positive!')
+            dist = 0.00001
+        elif dist > 1.0:
+            rospy.logwarn(' cannot set max distance greater than 1.0')
+            dist = 1.0
+        self._maximum_distance = dist
+
+    def get_last_point(self):
+        return deepcopy(self._last_point)
+
+    def get_next_point(self):
+        if self._lower_limit is None:
+            rospy.logerr('must define lower limits')
+            return None
+        elif self._upper_limit is None:
+            rospy.logerr('must define upper limits')
+            return None
+        elif self._last_point is None:
+            rospy.logerr('must define starting point')
+            return None
+        return self._get_next_point()
+
+    def _get_next_point(self):
+        point = []
+        for i in range(0, self._dimension):
+            low = self._lower_limit[i]
+            upp = self._upper_limit[i]
+            val = self._last_point[i]
+            point.append(self._get_special_bounded_float(low, val, upp))
+        self._last_point = point
+        return deepcopy(point)
+
+    def _get_special_bounded_float(self, low, val, upp):
+        """
+        @param low = hard lower bound on variable
+        @param upp = hard upper bound on variable
+        @param val = last sample value
+        @param pad = normalized passing to apply to boundaries
+        @param dist = normalized maximum distance from last value
+        """
+        pad = self._boundary_padding
+        dist = self._maximum_distance
+        r = upp - low
+        lower = max(low + pad*r, val - dist*r)
+        upper = min(upp - pad*r, val + dist*r)
+        if lower > upper:
+            print "No valid solution! Ignoring last sample value"
+            lower = low + pad*r
+            upper = upp - pad*r
+        return lower + (upper-lower)*random.random()
+
+    def _check_dimension(self, val):
+        if self._dimension is None:
+            self._dimension = len(val)
+            return True
+        elif self._dimension != len(val):
+            rospy.logerr('vector length is not consistent!')
+            return False
+        return True

--- a/intera_interface/src/intera_motion_interface/random_walk.py
+++ b/intera_interface/src/intera_motion_interface/random_walk.py
@@ -26,8 +26,9 @@ class RandomWalk(object):
 
     def __init__(self):
         """
-        Constructor - creates an empty random walk object. Be sure to set the
-        lower and upper limits, as well as the past point before calling.
+        Constructor - creates an empty random walk object.
+        Be sure to set the lower limits, upper limits, and past point before
+        calling getNextPoint().
         """
 
         self._lower_limit = None


### PR DESCRIPTION
Created a new python interface for accessing the joint limits. It listens to the /robot/joint_limits topic which may need to be added to the Gazebo simulator work.

This allows users to run the new send_random_trajectory.py script.

