### PR TITLE
Change when the FK service is called

### DIFF
--- a/intera_interface/src/intera_motion_interface/motion_trajectory.py
+++ b/intera_interface/src/intera_motion_interface/motion_trajectory.py
@@ -74,6 +74,7 @@ class MotionTrajectory(object):
         if not self._traj.waypoints:
             rospy.logerr("Trajectory is empty! Cannot send.")
             return None
+        self._check_options()
         self._client.send_trajectory(self.to_msg())
         result = self._client.wait_for_result()
         return result
@@ -170,3 +171,31 @@ class MotionTrajectory(object):
         with open(file_name, "wb") as f:
             writer = csv.writer(f)
             writer.writerows(waypoint_data)
+
+    def _check_options(self):
+        """
+        Check to make sure the defined waypoints have the necessary parameters
+        given the provided options and correct the waypoints when possible.
+        """
+        if (self._traj.trajectory_options.interpolation_type ==
+            TrajectoryOptions.CARTESIAN):
+            self._check_cartesian_options()
+
+    def _check_cartesian_options(self):
+        """
+        Checks the waypoints to make sure that cartesian endpoints are defined
+        and attempts to calculate them if possible
+        """
+        for index in range(len(self._traj.waypoints)):
+            wpt = self._traj.waypoints[index]
+            pose = wpt.pose.pose
+            position = [pose.position.x, pose.position.y, pose.position.z]
+            orientation = [pose.orientation.w, pose.orientation.x,
+                           pose.orientation.y, pose.orientation.z]
+            # If the endpoint pose has not been set
+            if not sum(position) or not sum(orientation):
+                new_wpt = MotionWaypoint(options = wpt.options)
+                new_wpt.set_joint_angles(joint_angles = wpt.joint_positions,
+                                         active_endpoint = wpt.active_endpoint,
+                                         perform_fk = True)
+                self._traj.waypoints[index] = new_wpt.to_msg()

--- a/intera_interface/src/intera_motion_interface/motion_trajectory.py
+++ b/intera_interface/src/intera_motion_interface/motion_trajectory.py
@@ -186,8 +186,7 @@ class MotionTrajectory(object):
         Checks the waypoints to make sure that cartesian endpoints are defined
         and attempts to calculate them if possible
         """
-        for index in range(len(self._traj.waypoints)):
-            wpt = self._traj.waypoints[index]
+        for index, wpt in enumerate(self._traj.waypoints):
             pose = wpt.pose.pose
             position = [pose.position.x, pose.position.y, pose.position.z]
             orientation = [pose.orientation.w, pose.orientation.x,

--- a/intera_interface/src/intera_motion_interface/motion_waypoint.py
+++ b/intera_interface/src/intera_motion_interface/motion_waypoint.py
@@ -110,13 +110,15 @@ class MotionWaypoint(object):
         return deepcopy(self._data.joint_positions)
 
     def set_joint_angles(self, joint_angles = [],
-                             active_endpoint = None):
+                         active_endpoint = None,
+                         perform_fk = False):
         """
         All parameters are optional. If ommitted or set to None, use default.
         @param joint_angles: the joint angles to store in the waypoint.
             If set to empty, then create an empty waypoint.
         @param active_endpoint: the pose is computed using the active endpoint
-
+        @param perform_fk: boolean to determine if FK should be performed with
+            the input joint angles
         """
         if joint_angles is None:
             joint_angles = MotionWaypoint.get_default_joint_angles()
@@ -124,7 +126,8 @@ class MotionWaypoint(object):
             active_endpoint = MotionWaypoint.get_default_active_endpoint()
 
         pose = PoseStamped()
-        if not joint_angles:   # empty joint angles, so...
+        # If joint angles don't exist or we don't want to computer FK:
+        if not perform_fk or not joint_angles:
             self._data.pose = pose   # empty pose as well
         else:   # Solve forward kinematics to get the pose
             joints = dict(zip(self._limb.joint_names(), joint_angles))


### PR DESCRIPTION
The FK service is being called on waypoints defined in joint space and with the intention of being run as joint trajectories. These calls are unnecessary. If a trajectory is run as a Cartesian trajectory but the waypoints have been defined in joint space, the FK service will be called when the trajectory is sent to the robot.