### PR TITLE
Remove unnecessary Limb class instantiations

### DIFF
--- a/intera_interface/src/intera_interface/limb.py
+++ b/intera_interface/src/intera_interface/limb.py
@@ -173,11 +173,11 @@ class Limb(object):
         err_msg = ("%s limb init failed to get current endpoint_state "
                    "from %s") % (self.name.capitalize(), ns + 'endpoint_state')
         intera_dataflow.wait_for(lambda: len(self._cartesian_pose.keys()) > 0,
-                                 timeout_msg=err_msg)
+                                 timeout_msg=err_msg, timeout=5.0)
         err_msg = ("%s limb init failed to get current tip_states "
                    "from %s") % (self.name.capitalize(), ns + 'tip_states')
         intera_dataflow.wait_for(lambda: self._tip_states is not None,
-                                 timeout_msg=err_msg)
+                                 timeout_msg=err_msg, timeout=5.0)
 
     def _on_joint_states(self, msg):
         for idx, name in enumerate(msg.name):

--- a/intera_interface/src/intera_motion_interface/motion_trajectory.py
+++ b/intera_interface/src/intera_motion_interface/motion_trajectory.py
@@ -64,9 +64,7 @@ class MotionTrajectory(object):
         # Used for sending the trajectory to the motion controller
         self._client = MotionControllerActionClient()
         self._traj = Trajectory()
-        self._limb = limb
-        if self._limb is None:
-            self._limb = Limb()
+        self._limb = limb or Limb()
 
         self.set_label(label)
         self.set_joint_names(joint_names)

--- a/intera_interface/src/intera_motion_interface/motion_trajectory.py
+++ b/intera_interface/src/intera_motion_interface/motion_trajectory.py
@@ -47,7 +47,8 @@ class MotionTrajectory(object):
 
     def __init__(self, label = None,
                  joint_names = None,
-                 trajectory_options = None):
+                 trajectory_options = None,
+                 limb = None):
         """
         Creates a new motion trajectory object.
         @param label: string
@@ -56,12 +57,16 @@ class MotionTrajectory(object):
             if joint_names is None: use default names
         @param trajectory_options: options for the trajectory
             if trajectory_options is None: use default options
+        @param limb: limb interface object.
+            If set to None, then create a new object
         """
 
         # Used for sending the trajectory to the motion controller
         self._client = MotionControllerActionClient()
         self._traj = Trajectory()
-        self._limb = Limb()
+        self._limb = limb
+        if self._limb is None:
+            self._limb = Limb()
 
         self.set_label(label)
         self.set_joint_names(joint_names)

--- a/intera_interface/src/intera_motion_interface/motion_waypoint.py
+++ b/intera_interface/src/intera_motion_interface/motion_waypoint.py
@@ -55,7 +55,8 @@ class MotionWaypoint(object):
 
     def __init__(self, joint_angles = [],
                  active_endpoint = None,
-                 options = None):
+                 options = None,
+                 limb = None):
         """
         Create a MotionWaypoint object.  All parameters are optional.
         @param joint_angles: the joint angles to store in the waypoint.
@@ -65,11 +66,15 @@ class MotionWaypoint(object):
             If set to None, then use default active endpoint
         @param options: waypoint options.
             If set to None, then use default waypoint options
+        @param limb: limb interface object.
+            If set to None, then create a new object
         @return: a intera Waypoint.msg object with default values
         """
         self._data = Waypoint()
 
-        self._limb = Limb()
+        self._limb = limb
+        if self._limb is None:
+            self._limb = Limb()
         self.set_joint_angles(joint_angles, active_endpoint)
         self.set_waypoint_options(options)
 

--- a/intera_interface/src/intera_motion_interface/motion_waypoint.py
+++ b/intera_interface/src/intera_motion_interface/motion_waypoint.py
@@ -71,10 +71,8 @@ class MotionWaypoint(object):
         @return: a intera Waypoint.msg object with default values
         """
         self._data = Waypoint()
+        self._limb = limb or Limb()
 
-        self._limb = limb
-        if self._limb is None:
-            self._limb = Limb()
         self.set_joint_angles(joint_angles, active_endpoint)
         self.set_waypoint_options(options)
 


### PR DESCRIPTION
Allow passing of existing Limb objects to MotionWaypoint and
MotionTrajectory classes to avoid extra instantiations of Limb.