### PR TITLE
Fix rospy_message_converter dependency issue 

### DIFF
--- a/intera_interface/package.xml
+++ b/intera_interface/package.xml
@@ -40,6 +40,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>
+  <run_depend>rospy_message_converter</run_depend>
   <run_depend>xacro</run_depend>
 
   <export>


### PR DESCRIPTION
This fixes an issue when pulling in the intera_sdk and using it in an overlay and then receiving the error: 
```
Traceback (most recent call last):
  File "/opt/rethink/mfg-build/lib/python2.7/dist-packages/intera_motion_interface/__init__.py", line 2, in <module>
    from .motion_trajectory import MotionTrajectory
  File "/opt/rethink/mfg-build/lib/python2.7/dist-packages/intera_motion_interface/motion_trajectory.py", line 38, in <module>
    from motion_waypoint import MotionWaypoint
  File "/opt/rethink/mfg-build/lib/python2.7/dist-packages/intera_motion_interface/motion_waypoint.py", line 30, in <module>
    from rospy_message_converter import message_converter
ImportError: No module named rospy_message_converter
```

when trying to run python scripts.