### PR TITLE
add rospy_message_converter as intera_interface build depend

### DIFF
--- a/intera_interface/package.xml
+++ b/intera_interface/package.xml
@@ -31,6 +31,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
+  <build_depend>rospy_message_converter</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
This pull request adds _rospy_message_converter_ as a build dependency in the _package.xml_ file of _intera_interface_. That addition resolves _catkin_make_ build failures. 