### PR TITLE
Set queue and buffer sizes in camera subscriber

### DIFF
--- a/intera_interface/src/intera_interface/camera.py
+++ b/intera_interface/src/intera_interface/camera.py
@@ -98,7 +98,7 @@ class Cameras(object):
         return False
 
     def set_callback(self, camera_name, callback, callback_args=None,
-        queue_size=10, rectify_image=True):
+        queue_size=1, buff_size=2**23, rectify_image=True):
         """
         Setup the callback function to show image.
 
@@ -110,6 +110,11 @@ class Cameras(object):
         @param callback_args: additional arguments to pass to the callback
         @type queue_size: int
         @param queue_size: maximum number of messages to receive at a time
+            Defaults to a queue size of 1 to grab the most recent image
+        @type buff_size: int
+        @param buff_size: incoming message buffer size in bytes.
+            Should be greater than the queue_size times the message size.
+            Defaults (8 MB) to be larger than a single head image of 4.1 MB.
         @type rectify_image: bool
         @param rectify_image: specify whether subscribe to the rectified or
                               raw (unrectified) image topic
@@ -123,7 +128,8 @@ class Cameras(object):
             else:
                 image_string = "image_raw"
             rospy.Subscriber('/'.join(["/io/internal_camera", camera_name,
-                image_string]), Image, callback, callback_args=callback_args)
+                image_string]), Image, callback, callback_args=callback_args,
+                queue_size=queue_size, buff_size=buff_size)
 
     def start_streaming(self, camera_name):
         """


### PR DESCRIPTION
The ROS subscriber buffer size needs to be increased to handle the large incoming images. It also looks like the queue_size parameter was not actually being used.

This mirrors PR #110 in the intera-tests-5.1.0 branch. A release note might be needed to let users know that the camera subscriber now defaults to a queue size of 1 instead of "infinite". Users can now actually set the queue_size now though.