### PR TITLE
Remove rospy_message_converter as a build dependency

### DIFF
--- a/intera_interface/CMakeLists.txt
+++ b/intera_interface/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(catkin
   dynamic_reconfigure
   intera_core_msgs
   intera_motion_msgs
-  rospy_message_converter
 )
 
 catkin_python_setup()
@@ -39,7 +38,6 @@ catkin_package(
   dynamic_reconfigure
   intera_core_msgs
   intera_motion_msgs
-  rospy_message_converter
 )
 
 install(


### PR DESCRIPTION
This undoes part of #108 which caused build errors because rospy_message_converter is not needed as a build time dependency. This is a cleaner fix than #109.