### PR TITLE
Make interaction control more transparent for SDK

### DIFF
--- a/intera_examples/scripts/go_to_joint_angles_in_contact.py
+++ b/intera_examples/scripts/go_to_joint_angles_in_contact.py
@@ -146,6 +146,13 @@ def main():
         "-kn", "--K_nullspace", type=float,
         nargs='+', default=[5.0, 10.0, 5.0, 10.0, 5.0, 10.0, 5.0],
         help="A list of desired nullspace stiffnesses, one for each of the 7 joints (a single value can be provided to apply the same value to all the directions) -- units are in (Nm/rad)")
+    parser.add_argument(
+        "-ddifc",  "--disable_damping_in_force_control", action='store_true', default=False,
+        help="Disable damping in force control")
+    parser.add_argument(
+        "-drr",  "--disable_reference_resetting", action='store_true', default=False,
+        help="The reference signal is reset to actual position to avoid jerks/jumps when interaction parameters are changed. This option allows the user to disable this feature.")
+
 
     args = parser.parse_args(rospy.myargv()[1:])
 
@@ -212,6 +219,10 @@ def main():
                     rospy.logerr('Invalid input to quaternion!')
             else:
                 rospy.logerr('Invalid input to interaction_frame!')
+
+        interaction_options.set_disable_damping_in_force_control(args.disable_damping_in_force_control)
+        interaction_options.set_disable_reference_resetting(args.disable_reference_resetting)
+
 
         trajectory_options.interaction_params = interaction_options.to_msg()
         traj.set_trajectory_options(trajectory_options)

--- a/intera_examples/scripts/set_interaction_options.py
+++ b/intera_examples/scripts/set_interaction_options.py
@@ -124,6 +124,13 @@ def main():
     parser.add_argument(
         "-r",  "--rate", type=int, default=10,
         help="A desired publish rate for updating interaction control commands (10Hz by default) -- 0 if we want to publish it only once")
+    parser.add_argument(
+        "-ddifc",  "--disable_damping_in_force_control", action='store_true', default=False,
+        help="Disable damping in force control")
+
+    parser.add_argument(
+        "-drr",  "--disable_reference_resetting", action='store_true', default=False,
+        help="The reference signal is reset to actual position to avoid jerks/jumps when interaction parameters are changed. This option allows the user to disable this feature.")
 
     args = parser.parse_args(rospy.myargv()[1:])
 
@@ -177,6 +184,9 @@ def main():
                     rospy.logerr('Invalid input to quaternion!')
             else:
                 rospy.logerr('Invalid input to interaction_frame!')
+
+        interaction_options.set_disable_damping_in_force_control(args.disable_damping_in_force_control)
+        interaction_options.set_disable_reference_resetting(args.disable_reference_resetting)
 
         msg = interaction_options.to_msg()
 

--- a/intera_interface/src/intera_motion_interface/interaction_options.py
+++ b/intera_interface/src/intera_motion_interface/interaction_options.py
@@ -47,6 +47,8 @@ class InteractionOptions(object):
     default_in_endpoint_frame = False
     default_force_command = 0.0
     default_interaction_mode = impedance_mode
+    default_disable_damping_in_force_control = False
+    default_disable_reference_resetting = False
 
     def __init__(self, header = None,
                  interaction_control_active = None,
@@ -58,7 +60,9 @@ class InteractionOptions(object):
                  interaction_frame = None,
                  endpoint_name = None,
                  in_endpoint_frame = None,
-                 interaction_control_mode = None):
+                 interaction_control_mode = None,
+                 disable_damping_in_force_control = None,
+                 disable_reference_resetting = None):
         """
         Create a interaction options object. All parameters are
         optional. If ommitted or set to None, then use default value.
@@ -77,6 +81,8 @@ class InteractionOptions(object):
         self.set_endpoint_name(endpoint_name)
         self.set_in_endpoint_frame(in_endpoint_frame)
         self.set_interaction_control_mode(interaction_control_mode)
+        self.set_disable_damping_in_force_control(disable_damping_in_force_control)
+        self.set_disable_reference_resetting(disable_reference_resetting)
 
     def set_header(self, header = None):
         """
@@ -238,6 +244,29 @@ class InteractionOptions(object):
             else:
                 rospy.logerr('The number of interaction_control_mode elements must be 1 or %d',
                              self.n_dim_cart)
+
+    def set_disable_damping_in_force_control(self, disable_damping_in_force_control = None):
+        """
+        @param disable_damping_in_force_control:
+          - None:  set it to False by default
+          - [bool]: copy the element.
+        """
+        if disable_damping_in_force_control is None:
+            self.set_disable_damping_in_force_control(self.default_disable_damping_in_force_control) # default value
+        else:
+            self._data.disable_damping_in_force_control = disable_damping_in_force_control
+
+    def set_disable_reference_resetting(self, disable_reference_resetting = None):
+        """
+        @param disable_reference_resetting:
+          - None:  set it to False by default
+          - [bool]: copy the element.
+        """
+        if disable_reference_resetting is None:
+            self.set_disable_reference_resetting(self.disable_reference_resetting) # default value
+        else:
+            self._data.disable_reference_resetting = disable_reference_resetting
+
 
     def to_msg(self):
         """

--- a/intera_interface/src/intera_motion_interface/interaction_options.py
+++ b/intera_interface/src/intera_motion_interface/interaction_options.py
@@ -245,27 +245,21 @@ class InteractionOptions(object):
                 rospy.logerr('The number of interaction_control_mode elements must be 1 or %d',
                              self.n_dim_cart)
 
-    def set_disable_damping_in_force_control(self, disable_damping_in_force_control = None):
+    def set_disable_damping_in_force_control(self, disable_damping_in_force_control = self.default_disable_damping_in_force_control):
         """
         @param disable_damping_in_force_control:
           - None:  set it to False by default
           - [bool]: copy the element.
         """
-        if disable_damping_in_force_control is None:
-            self.set_disable_damping_in_force_control(self.default_disable_damping_in_force_control) # default value
-        else:
-            self._data.disable_damping_in_force_control = disable_damping_in_force_control
+        self._data.disable_damping_in_force_control = disable_damping_in_force_control
 
-    def set_disable_reference_resetting(self, disable_reference_resetting = None):
+    def set_disable_reference_resetting(self, disable_reference_resetting = self.default_disable_reference_resetting):
         """
         @param disable_reference_resetting:
           - None:  set it to False by default
           - [bool]: copy the element.
         """
-        if disable_reference_resetting is None:
-            self.set_disable_reference_resetting(self.disable_reference_resetting) # default value
-        else:
-            self._data.disable_reference_resetting = disable_reference_resetting
+        self._data.disable_reference_resetting = disable_reference_resetting
 
 
     def to_msg(self):

--- a/intera_interface/src/intera_motion_interface/interaction_options.py
+++ b/intera_interface/src/intera_motion_interface/interaction_options.py
@@ -245,7 +245,7 @@ class InteractionOptions(object):
                 rospy.logerr('The number of interaction_control_mode elements must be 1 or %d',
                              self.n_dim_cart)
 
-    def set_disable_damping_in_force_control(self, disable_damping_in_force_control = self.default_disable_damping_in_force_control):
+    def set_disable_damping_in_force_control(self, disable_damping_in_force_control = default_disable_damping_in_force_control):
         """
         @param disable_damping_in_force_control:
           - None:  set it to False by default
@@ -253,7 +253,7 @@ class InteractionOptions(object):
         """
         self._data.disable_damping_in_force_control = disable_damping_in_force_control
 
-    def set_disable_reference_resetting(self, disable_reference_resetting = self.default_disable_reference_resetting):
+    def set_disable_reference_resetting(self, disable_reference_resetting = default_disable_reference_resetting):
         """
         @param disable_reference_resetting:
           - None:  set it to False by default


### PR DESCRIPTION
This commit introduces two options that will
make interaction control more transparent:
1. Allow users to disable damping in the force mode.
2. Allow users to remove reference resetting.