### PR TITLE
Fix lights example toggle

### DIFF
--- a/intera_examples/scripts/lights_blink.py
+++ b/intera_examples/scripts/lights_blink.py
@@ -27,22 +27,26 @@ def test_light_interface(light_name='head_green_light'):
     rospy.loginfo("All available lights on this robot:\n{0}\n".format(
                                                ', '.join(l.list_all_lights())))
     rospy.loginfo("Blinking Light: {0}".format(light_name))
+    initial_state = l.get_light_state(light_name)
     on_off = lambda x: 'ON' if l.get_light_state(x) else 'OFF'
     rospy.loginfo("Initial state: {0}".format(on_off(light_name)))
-    # turn on light
-    l.set_light_state(light_name, True)
+    # invert light
+    state = not initial_state
+    l.set_light_state(light_name, state)
     rospy.sleep(1)
     rospy.loginfo("New state: {0}".format(on_off(light_name)))
-    # turn off light
-    l.set_light_state(light_name, False)
+    # invert light
+    state = not state
+    l.set_light_state(light_name, state)
     rospy.sleep(1)
     rospy.loginfo("New state: {0}".format(on_off(light_name)))
-    # turn on light
-    l.set_light_state(light_name, True)
+    # invert light
+    state = not state
+    l.set_light_state(light_name, state)
     rospy.sleep(1)
     rospy.loginfo("New state: {0}".format(on_off(light_name)))
     # reset output
-    l.set_light_state(light_name, False)
+    l.set_light_state(light_name, initial_state)
     rospy.sleep(1)
     rospy.loginfo("Final state: {0}".format(on_off(light_name)))
 


### PR DESCRIPTION
The lights example was not preserving
the initial state of the lights when toggling.
This change now preserves the initial lights
state.