### PR TITLE
Catch and report missing cameras

### DIFF
--- a/intera_examples/scripts/camera_display.py
+++ b/intera_examples/scripts/camera_display.py
@@ -71,7 +71,12 @@ def main():
 
     print("Initializing node... ")
     rospy.init_node('camera_display', anonymous=True)
-    camera = intera_interface.Cameras()
+    try:
+        camera = intera_interface.Cameras()
+    except OSError as e:
+        rospy.logfatal("Could not find all of the expected cameras for this robot.\n"
+                "Please contact Rethink support: support@rethinkrobotics.com")
+        return
     if not camera.verify_camera_exists(args.camera):
         rospy.logerr("Invalid camera name, exiting the example.")
         return


### PR DESCRIPTION
This commit catches missing cameras in the `camera_display`
example. If one of the cameras is missing, the example would
not perform properly, and report a confusing `OSError`.

Instead, we now catch this error, describe the issue, and
recommend the user contact Rethink Support.

Fixes IN-3629, tested on PV3 with an unplugged head camera.