### PR TITLE
Adding motion_interface timeout functionality (#118)

### DIFF
--- a/intera_examples/scripts/go_to_cartesian_pose.py
+++ b/intera_examples/scripts/go_to_cartesian_pose.py
@@ -86,6 +86,9 @@ def main():
     parser.add_argument(
         "--rotational_accel", type=float, default=1.57,
         help="The max rotational acceleration of the endpoint (rad/s/s)")
+    parser.add_argument(
+        "--timeout", type=float, default=None,
+        help="Max time in seconds to complete motion goal before returning. None is interpreted as an infinite timeout.")
     args = parser.parse_args(rospy.myargv()[1:])
 
     try:
@@ -161,7 +164,7 @@ def main():
 
         traj.append_waypoint(waypoint.to_msg())
 
-        result = traj.send_trajectory()
+        result = traj.send_trajectory(timeout=args.timeout)
         if result is None:
             rospy.logerr('Trajectory FAILED to send')
             return

--- a/intera_examples/scripts/go_to_joint_angles.py
+++ b/intera_examples/scripts/go_to_joint_angles.py
@@ -51,6 +51,9 @@ def main():
     parser.add_argument(
         "-a",  "--accel_ratio", type=float, default=0.5,
         help="A value between 0.001 (slow) and 1.0 (maximum joint accel)")
+    parser.add_argument(
+        "--timeout", type=float, default=None,
+        help="Max time in seconds to complete motion goal before returning. None is interpreted as an infinite timeout.")
     args = parser.parse_args(rospy.myargv()[1:])
 
     try:
@@ -74,7 +77,7 @@ def main():
         waypoint.set_joint_angles(joint_angles = args.joint_angles)
         traj.append_waypoint(waypoint.to_msg())
 
-        result = traj.send_trajectory()
+        result = traj.send_trajectory(timeout=args.timeout)
         if result is None:
             rospy.logerr('Trajectory FAILED to send')
             return

--- a/intera_examples/scripts/go_to_joint_angles_in_contact.py
+++ b/intera_examples/scripts/go_to_joint_angles_in_contact.py
@@ -140,6 +140,9 @@ def main():
     parser.add_argument(
         "-rc",  "--rotations_for_constrained_zeroG", action='store_true', default=False,
         help="Allow arbitrary rotational displacements from the current orientation for constrained zero-G (use only for a stationary reference orientation)")
+    parser.add_argument(
+        "--timeout", type=float, default=None,
+        help="Max time in seconds to complete motion goal before returning. None is interpreted as an infinite timeout.")
 
     args = parser.parse_args(rospy.myargv()[1:])
 
@@ -204,7 +207,7 @@ def main():
         trajectory_options.interaction_params = interaction_options.to_msg()
         traj.set_trajectory_options(trajectory_options)
 
-        result = traj.send_trajectory()
+        result = traj.send_trajectory(timeout=args.timeout)
         if result is None:
             rospy.logerr('Trajectory FAILED to send!')
             return

--- a/intera_examples/scripts/send_random_trajectory.py
+++ b/intera_examples/scripts/send_random_trajectory.py
@@ -98,6 +98,9 @@ def main():
     parser.add_argument(
         "--log_file_output",
         help="Save motion controller log messages to this file name")
+    parser.add_argument(
+        "--timeout", type=float, default=None,
+        help="Max time in seconds to complete motion goal before returning. None is interpreted as an infinite timeout.")
     args = parser.parse_args()
 
     if args.waypoint_count < 1:
@@ -159,8 +162,7 @@ def main():
             traj.set_log_file_name(args.log_file_output)
 
         if not args.do_not_send:
-            result = traj.send_trajectory()
-
+            result = traj.send_trajectory(timeout=args.timeout)
             if result is None:
                 rospy.logerr('Trajectory FAILED to send')
             elif result.result:
@@ -169,7 +171,7 @@ def main():
                 rospy.logerr('Motion controller failed to complete the trajectory with error %s',
                              result.errorId)
     except rospy.ROSInterruptException:
-        rospy.logerr('Keyboard interrupt detected from the user. %s',
+        rospy.logerr('Keyboard interrupt detected from the user. '
                      'Exiting before trajectory completion.')
 
 if __name__ == '__main__':

--- a/intera_interface/src/intera_motion_interface/motion_controller_action_client.py
+++ b/intera_interface/src/intera_motion_interface/motion_controller_action_client.py
@@ -61,12 +61,16 @@ class MotionControllerActionClient(object):
         goal.trajectory = trajectory
         self._client.send_goal(goal)
 
-    def wait_for_result(self):
+    def wait_for_result(self, timeout=None):
         """
         Wait for the current task to finish and then return the result
+        @param timeout: maximum time to wait. If timeout is reached, return None.
         @return: the result of the MotionCommand.action
         """
-        self._client.wait_for_result()
+        if timeout is None:
+             self._client.wait_for_result()
+        else:
+            self._client.wait_for_result(rospy.Duration(timeout))
         return self._client.get_result()
 
     def get_state(self):

--- a/intera_interface/src/intera_motion_interface/motion_trajectory.py
+++ b/intera_interface/src/intera_motion_interface/motion_trajectory.py
@@ -70,14 +70,16 @@ class MotionTrajectory(object):
         """
         self._client.stop_trajectory()
 
-    def send_trajectory(self, wait_for_result=True):
+    def send_trajectory(self, wait_for_result=True, timeout=None):
         """
         Checks the trajectory message is complete.
         The message then will be packaged up with the MOTION_START
         command and sent to the motion controller.
         @param wait_for_result:
-          - If true, the function will not until the trajectory is finished
+          - If true, the function will not return until the trajectory is finished
           - If false, return True immediately after sending
+        @param timeout: maximum time to wait for trajectory result.
+          - If timeout is reached, return None.
         @return: True if the goal finished
         @rtype: bool
         """
@@ -86,7 +88,7 @@ class MotionTrajectory(object):
             return None
         self._check_options()
         self._client.send_trajectory(self.to_msg())
-        return self._client.wait_for_result() if wait_for_result else True
+        return self._client.wait_for_result(timeout) if wait_for_result else True
 
     def get_state(self):
         """
@@ -95,12 +97,16 @@ class MotionTrajectory(object):
         """
         return self._client.get_state()
 
-    def wait_for_result(self):
+    def wait_for_result(self, timeout=None):
         """
-        The function will not until the trajectory is finished
-        @return True if the goal finished
+        The function will wait until the trajectory is finished,
+        or the specified timeout is reached.
+        @param timeout: maximum time to wait. 
+        @return None if timeout is reached, else
+                True if the goal is achieved
+                False if failed to achieve goal
         """
-        return self._client.wait_for_result()
+        return self._client.wait_for_result(timeout)
 
     def set_data(self, traj_msg):
         """


### PR DESCRIPTION
* Adding timeout functionality to `wait_for_result()` and `send_trajectory()` to block the time before returning.

* Improving documentation and clean-up the code

* Adding documentation to `send_trajectory`

(cherry picked from commit 894c2254543ae68cf9b6beceec3e46be753bf84c)

@asthakukreja and @rethink-forrest, I had to resolve a few conflicts to perform this cherry-pick. Can you please give this a look through to make sure I haven't clobbered anything?