### PR TITLE
Gripper Class and Example updates

### DIFF
--- a/intera_examples/scripts/joint_position_keyboard.py
+++ b/intera_examples/scripts/joint_position_keyboard.py
@@ -34,7 +34,7 @@ def map_keyboard(side):
         gripper = intera_interface.Gripper(side + '_gripper')
     except:
         has_gripper = False
-        rospy.logerr("Could not initialize the gripper.")
+        rospy.loginfo("The electric gripper is not detected on the robot.")
     else:
         has_gripper = True
 
@@ -68,11 +68,14 @@ def map_keyboard(side):
         '6': (set_j, [limb, joints[5], 0.1], joints[5]+" increase"),
         'y': (set_j, [limb, joints[5], -0.1], joints[5]+" decrease"),
         '7': (set_j, [limb, joints[6], 0.1], joints[6]+" increase"),
-        'u': (set_j, [limb, joints[6], -0.1], joints[6]+" decrease"),
+        'u': (set_j, [limb, joints[6], -0.1], joints[6]+" decrease")
+     }
+    if has_gripper:
+        bindings.update({
         '8': (set_g, "close", side+" gripper close"),
         'i': (set_g, "open", side+" gripper open"),
         '9': (set_g, "calibrate", side+" gripper calibrate")
-     }
+        })
     done = False
     print("Controlling joints. Press ? for help, Esc to quit.")
     while not done and not rospy.is_shutdown():

--- a/intera_interface/src/intera_interface/gripper.py
+++ b/intera_interface/src/intera_interface/gripper.py
@@ -24,8 +24,6 @@ class Gripper(object):
     """
     MAX_POSITION = 0.041667
     MIN_POSITION = 0.0
-    MAX_FORCE = 10.0
-    MIN_FORCE = 0.0
     MAX_VELOCITY = 3.0
     MIN_VELOCITY = 0.15
 
@@ -191,12 +189,34 @@ class Gripper(object):
 
     def set_velocity(self, speed):
         """
+        DEPRECATED: Use set_cmd_velocity(speed)
+
         Set the velocity at which the gripper position movement will execute.
 
         @type: float
         @param: the velocity of gripper in meters per second (m/s)
         """
+        self.set_cmd_velocity(speed)
+
+    def set_cmd_velocity(self, speed):
+        """
+        Set the commanded velocity at which the gripper position
+        movement will execute.
+
+        @type: float
+        @param: the velocity of gripper in meters per second (m/s)
+        """
         self.gripper_io.set_signal_value("speed_mps", speed)
+
+    def get_cmd_velocity(self):
+        """
+        Get the commanded velocity at which the gripper position
+        movement executes.
+
+        @rtype: float
+        @return: the velocity of gripper in meters per second (m/s)
+        """
+        return self.gripper_io.get_signal_value("speed_mps")
 
     def get_force(self):
         """
@@ -218,7 +238,20 @@ class Gripper(object):
         @type: float
         @param: the object weight in kilograms (kg)
         """
-        self.gripper_io.set_signal_value("object_kg", object_weight)
+        self.gripper_io.set_signal_value(self.name+"_tip_object_kg", object_weight)
+
+    def get_object_weight(self):
+        """
+        Get the currently configured weight of the object in kilograms.
+
+        Object mass is set as a point mass at the location of the tool endpoint
+        link in the URDF (e.g. 'right_gripper_tip'). The robot's URDF and
+        internal robot model will be updated to compensate for the mass.
+
+        @rtype: float
+        @return: the object weight in kilograms (kg)
+        """
+        return self.gripper_io.get_signal_value(self.name+"_tip_object_kg")
 
     def set_dead_zone(self, dead_zone):
         """
@@ -229,6 +262,16 @@ class Gripper(object):
         @param: the dead zone of gripper in meters
         """
         self.gripper_io.set_signal_value("dead_zone_m", dead_zone)
+
+    def get_dead_zone(self):
+        """
+        Get the gripper dead zone describing the position error threshold
+        where a move will be considered successful.
+
+        @rtype: float
+        @return: the dead zone of gripper in meters
+        """
+        return self.gripper_io.get_signal_value("dead_zone_m")
 
     def set_holding_force(self, holding_force):
         """


### PR DESCRIPTION
- Adds `get_dead_zone()` and `get_object_weight()` functions to `Gripper`
  class
- Fixed a bug in `object_kg` signals in `Gripper` class
- Adds `set_cmd_velocity()` and `get_cmd_velocity()` in `Gripper` class,
  while deprecating `set_velocity()` because it was too ambiguous
- Removed unused `MAX` and `MIN FORCE` constants
- Reports an info message (rather than an error) when no `Gripper` is
  plugged in when running `joint_position_keyboard`
- Fixes `gripper_keyboard` example to incrementally open and close
  the gripper position, even when at the 0 position
- Fixes `gripper_joystick` example to incrementally open at 0 position,
  and removes the force nudging (which could cause jamming)