### PR TITLE
Update gripper_keyboard ex to use set_cmd_velocity

### DIFF
--- a/intera_examples/scripts/gripper_keyboard.py
+++ b/intera_examples/scripts/gripper_keyboard.py
@@ -51,7 +51,7 @@ def map_keyboard(limb):
 
     def update_velocity(offset_vel):
         cmd_speed = max(min(gripper.get_cmd_velocity() + offset_vel, gripper.MAX_VELOCITY), gripper.MIN_VELOCITY)
-        gripper.set_velocity(cmd_speed)
+        gripper.set_cmd_velocity(cmd_speed)
         print("commanded velocity set to {0} m/s".format(cmd_speed))
 
 


### PR DESCRIPTION
To prevent deprecation warnings from being emitted to the user, this updates
the gripper_keyboard example to use the new interface "set_cmd_velocity".