### PR TITLE
Updates gripper_joystick for new set_cmd_velocity

### DIFF
--- a/intera_examples/scripts/gripper_joystick.py
+++ b/intera_examples/scripts/gripper_joystick.py
@@ -70,7 +70,7 @@ def map_joystick(joystick, limb):
 
     def update_velocity(offset_vel):
         cmd_speed = max(min(gripper.get_cmd_velocity() + offset_vel, gripper.MAX_VELOCITY), gripper.MIN_VELOCITY)
-        gripper.set_velocity(cmd_speed)
+        gripper.set_cmd_velocity(cmd_speed)
         print("commanded velocity set to {0} m/s".format(cmd_speed))
 
 


### PR DESCRIPTION
Updates the deprecated `Gripper.set_velocity()` call to use the non-deprecated
`set_cmd_velocity()`