### PR TITLE
Added script to stop the current motion trajectory

### DIFF
--- a/intera_examples/scripts/stop_motion_trajectory.py
+++ b/intera_examples/scripts/stop_motion_trajectory.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+
+# Copyright (c) 2017, Rethink Robotics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rospy
+from intera_motion_interface import MotionTrajectory
+
+def main():
+    """
+    Send a STOP command to the motion controller, which will safely stop the
+    motion controller if it is actively running a trajectory. This is useful
+    when the robot is executing a long trajectory that needs to be canceled.
+    Note: This will only stop motions that are running through the motion
+    controller. It will not stop the motor controllers from receiving commands
+    send directly from a custom ROS node.
+
+    $ rosrun intera_examples stop_motion_trajectory.py
+    """
+
+    try:
+        rospy.init_node('stop_motion_trajectory')
+        traj = MotionTrajectory()
+        result = traj.stop_trajectory()
+
+        if result is None:
+            rospy.logerr('FAILED to send stop request')
+            return
+
+        if result.result:
+            rospy.loginfo('Motion controller successfully stopped the motion!')
+        else:
+            rospy.logerr('Motion controller failed to stop the motion: %s',
+                         result.errorId)
+
+    except rospy.ROSInterruptException:
+        rospy.logerr('Keyboard interrupt detected from the user. Exiting before stop completion.')
+
+
+if __name__ == '__main__':
+    main()

--- a/intera_interface/src/intera_motion_interface/motion_controller_action_client.py
+++ b/intera_interface/src/intera_motion_interface/motion_controller_action_client.py
@@ -48,7 +48,6 @@ class MotionControllerActionClient(object):
         goal = intera_motion_msgs.msg.MotionCommandGoal()
         goal.command = intera_motion_msgs.msg.MotionCommandGoal.MOTION_STOP
         self._client.send_goal(goal)
-        rospy.loginfo('Stopping trajectory')
 
     def send_trajectory(self, trajectory):
         """

--- a/intera_interface/src/intera_motion_interface/motion_trajectory.py
+++ b/intera_interface/src/intera_motion_interface/motion_trajectory.py
@@ -64,11 +64,12 @@ class MotionTrajectory(object):
         self.set_joint_names(joint_names)
         self.set_trajectory_options(trajectory_options)
 
-    def stop_trajectory(self):
+    def stop_trajectory(self, wait_for_result=True, timeout=None):
         """
         Send a Motion Stop command
         """
         self._client.stop_trajectory()
+        return self._client.wait_for_result(timeout) if wait_for_result else True
 
     def send_trajectory(self, wait_for_result=True, timeout=None):
         """
@@ -101,7 +102,7 @@ class MotionTrajectory(object):
         """
         The function will wait until the trajectory is finished,
         or the specified timeout is reached.
-        @param timeout: maximum time to wait. 
+        @param timeout: maximum time to wait.
         @return None if timeout is reached, else
                 True if the goal is achieved
                 False if failed to achieve goal


### PR DESCRIPTION
This commit adds a script that stops an active motion trajectory. This is useful when the motion controller is running a long trajectory that needs to be canceled.

I also made small modifications to the `MotionTrajectory` and `MotionControllerActionClient` classes to make the `stop()` methods behave more like the `send()` methods.