### PR TITLE
Update version to 5.4.0. Remove unused VERSIONS_SDK2GRIPPER

### DIFF
--- a/intera_examples/package.xml
+++ b/intera_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>intera_examples</name>
-  <version>5.3.0</version>
+  <version>5.4.0</version>
   <description>
     Example programs for Intera SDK usage.
   </description>

--- a/intera_interface/package.xml
+++ b/intera_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>intera_interface</name>
-  <version>5.3.0</version>
+  <version>5.4.0</version>
   <description>
     Python interface classes for control of
     Intera-enable Robots from Rethink Robotics.

--- a/intera_interface/src/intera_interface/__init__.py
+++ b/intera_interface/src/intera_interface/__init__.py
@@ -32,5 +32,4 @@ from .settings import (
     SDK_VERSION,
     CHECK_VERSION,
     VERSIONS_SDK2ROBOT,
-    VERSIONS_SDK2GRIPPER,
 )

--- a/intera_interface/src/intera_interface/settings.py
+++ b/intera_interface/src/intera_interface/settings.py
@@ -16,16 +16,11 @@ JOINT_ANGLE_TOLERANCE = 0.008726646
 HEAD_PAN_ANGLE_TOLERANCE = 0.1
 
 ## Versioning
-SDK_VERSION = '5.3.0'
+SDK_VERSION = '5.4.0'
 CHECK_VERSION = True
 # Version Compatibility Maps - {current: compatible}
 VERSIONS_SDK2ROBOT = {'5.1.0': ['5.1.0', '5.1.1', '5.1.2'],
                       '5.2.0': ['5.2.0', '5.2.1', '5.2.2'],
-                      '5.3.0': ['5.3.0']
+                      '5.3.0': ['5.3.0'],
+                      '5.4.0': ['5.4.0'],
                      }
-VERSIONS_SDK2GRIPPER = {'5.3.0':
-                          {
-                           'warn': '2014/5/20 00:00:00',  # Version 1.0.0
-                           'fail': '2013/10/15 00:00:00', # Version 0.6.2
-                          }
-                       }

--- a/intera_sdk/package.xml
+++ b/intera_sdk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>intera_sdk</name>
-  <version>5.3.0</version>
+  <version>5.4.0</version>
   <description>
     intera_sdk metapackage containing all of the SDK packages
     for Rethink Robotics' robots.


### PR DESCRIPTION
Tested that everything built and ran fine in simulation. Previously, the the enable_robot.py script would not run because of mismatched Intera version numbers.