### PR TITLE
Adds Cognex camera light strobe function

### DIFF
--- a/intera_interface/src/intera_interface/camera.py
+++ b/intera_interface/src/intera_interface/camera.py
@@ -346,3 +346,22 @@ class Cameras(object):
                     rospy.logerr("Problem setting signal: {}".format(status or "Signal Not Found"))
 
         return success
+
+    def set_cognex_strobe(self, value):
+        """
+        Set the strobe on the Cognex right_hand_camera only.
+
+        @type value: bool
+        @param value: True for strobe on, False for strobe off
+
+        @rtype: bool
+        @return: False, if Cognex camera is not available and
+                 True, otherwise.
+        """
+        success = True
+        try:
+            self.cameras_io['right_hand_camera']['interface'].set_signal_value('set_strobe', bool(value))
+        except KeyError as e:
+            success = False
+            rospy.logerr("Cannot find Cognex camera with the name {}".format(e))
+        return success


### PR DESCRIPTION
While setting the camera strobe light is possible with the current SDK, this makes it very straightforward for a user to turn the strobe on and off. See recent comments in #52