### PR TITLE
Exit Interaction Control mode when exiting scripts

### DIFF
--- a/intera_examples/scripts/constrained_zeroG.py
+++ b/intera_examples/scripts/constrained_zeroG.py
@@ -24,16 +24,168 @@ from intera_motion_interface.utility_functions import (int2bool, bool2int, boolT
 import intera_interface
 from intera_interface import CHECK_VERSION
 
+class ConstrainedZeroG(object):
+    """
+    Send interaction commands to place the robot in constrained zero-g mode
+    """
+
+    def __init__(self, args):
+        self.pub = rospy.Publisher('/robot/limb/right/interaction_control_command',
+                              InteractionControlCommand, queue_size = 1)
+        rospy.sleep(0.5)
+
+        self.repeat = False
+        if args.rate > 0:
+            self.rate = rospy.Rate(args.rate)
+            self.repeat = True
+        elif args.rate == 0:
+            rospy.logwarn('Interaction control options will be set only once!')
+        elif args.rate < 0:
+            rospy.logerr('Invalid publish rate!')
+
+        # set the interaction control options in the current configuration
+        interaction_options = InteractionOptions()
+
+        # if one of the options is set
+        unconstrained_axes_default = [0, 0, 0, 0, 0, 0]
+        unconstrained_axes = unconstrained_axes_default
+
+        # create a list of the constrained zero G modes
+        sum_mode_list = sum(bool2int([args.position_only, args.orientation_only,
+                                      args.plane_horizontal, args.plane_vertical_xz,
+                                      args.plane_vertical_yz, args.nullspace_only]))
+
+        # create a list of the free axis options
+        free_axis_list = bool2int([args.position_x, args.position_y, args.position_z,
+                                   args.orientation_x, args.orientation_y, args.orientation_z])
+        sum_free_axis_list = sum(free_axis_list)
+
+        zero_stiffness_axes = boolToggle(args.constrained_axes)
+        sum_zero_stiffness_axes = sum(zero_stiffness_axes)
+
+        if (sum_mode_list==0 and sum_zero_stiffness_axes==0 and sum_free_axis_list==0):
+            rospy.logerr('You need to either set one of the options or specify the ' \
+                         'desired axes of arbitrary movement!')
+            rospy.logerr('The movement of endpoint will be constrained in all directions!')
+
+        if (sum_mode_list>1 and sum_zero_stiffness_axes==0 and sum_free_axis_list==0):
+            rospy.logerr('You can set only one of the options among "pos_only", "ori_only", ' \
+                         '"plane_hor", and "plane_ver"!')
+            rospy.logerr('The movement of endpoint will be constrained in all directions!')
+
+        # give an error if the mode options as well as the individual axis options are set
+        if (sum_mode_list==1 and sum_zero_stiffness_axes==0 and sum_free_axis_list>0):
+            rospy.logerr('The individual axis options cannot be used together with the mode options!')
+            rospy.logerr('The movement of endpoint will be constrained in all directions!')
+
+        # give an error when the axes are specified by more than one method
+        if (sum_mode_list==0 and sum_zero_stiffness_axes>0 and sum_free_axis_list>0):
+            rospy.logerr('You can only set the axes either by an array or individual options!')
+            rospy.logerr('The movement of endpoint will be constrained in all directions!')
+
+        if (sum_mode_list==1 and sum_zero_stiffness_axes==0 and sum_free_axis_list>=0):
+            if args.position_only:
+                unconstrained_axes = [1, 1, 1, 0, 0, 0]
+            if args.orientation_only:
+                unconstrained_axes = [0, 0, 0, 1, 1, 1]
+            if args.plane_horizontal:
+                unconstrained_axes = [1, 1, 0, 0, 0, 0]
+            if args.plane_vertical_xz:
+                unconstrained_axes = [1, 0, 1, 0, 0, 0]
+            if args.plane_vertical_yz:
+                unconstrained_axes = [0, 1, 1, 0, 0, 0]
+            if args.nullspace_only:
+                unconstrained_axes = [0, 0, 0, 0, 0, 0]
+
+        # if the axes are specified by an array
+        if (sum_mode_list==0 and sum_zero_stiffness_axes>0 and sum_free_axis_list==0):
+            unconstrained_axes = zero_stiffness_axes
+
+        # if the axes are specified by individual options
+        if (sum_mode_list==0 and sum_zero_stiffness_axes==0 and sum_free_axis_list>0):
+            unconstrained_axes = free_axis_list
+
+        # set the stiffness to zero by default
+        interaction_options.set_K_impedance([0, 0, 0, 0, 0, 0])
+
+        # set the axes with maximum stiffness
+        interaction_options.set_max_impedance(boolToggle(int2bool(unconstrained_axes)))
+
+        interaction_options.set_in_endpoint_frame(args.in_endpoint_frame)
+
+        # set nullspace stiffness to zero if nullspace_only option is provided
+        if args.nullspace_only:
+            K_nullspace = [0, 0, 0, 0, 0, 0, 0]
+        else:
+            K_nullspace = args.K_nullspace
+
+        interaction_options.set_K_nullspace(K_nullspace)
+
+        if len(args.interaction_frame) < 7:
+            rospy.logerr('The number of elements must be 7!')
+        elif len(args.interaction_frame) == 7:
+            quat_sum_square = (args.interaction_frame[3]*args.interaction_frame[3]
+                              + args.interaction_frame[4]*args.interaction_frame[4]
+                              + args.interaction_frame[5]*args.interaction_frame[5]
+                              + args.interaction_frame[6]*args.interaction_frame[6])
+            if quat_sum_square  < 1.0 + 1e-7 and quat_sum_square > 1.0 - 1e-7:
+                interaction_frame = Pose()
+                interaction_frame.position.x = args.interaction_frame[0]
+                interaction_frame.position.y = args.interaction_frame[1]
+                interaction_frame.position.z = args.interaction_frame[2]
+                interaction_frame.orientation.w = args.interaction_frame[3]
+                interaction_frame.orientation.x = args.interaction_frame[4]
+                interaction_frame.orientation.y = args.interaction_frame[5]
+                interaction_frame.orientation.z = args.interaction_frame[6]
+                interaction_options.set_interaction_frame(interaction_frame)
+            else:
+                rospy.logerr('Invalid input to quaternion! The quaternion must be a unit quaternion!')
+        else:
+            rospy.logerr('Invalid input to interaction_frame!')
+
+        # always enable the rotations for constrained zero-G
+        interaction_options.set_rotations_for_constrained_zeroG(True)
+
+        self.msg = interaction_options.to_msg()
+
+    def send_msg(self):
+        try:
+            # print the resultant interaction options once
+            rospy.loginfo(self.msg)
+            self.pub.publish(self.msg)
+            rs = intera_interface.RobotEnable(CHECK_VERSION)
+            if self.repeat:
+                while not rospy.is_shutdown() and rs.state().enabled:
+                    self.rate.sleep()
+                    self.pub.publish(self.msg)
+        except rospy.ROSInterruptException:
+            rospy.logerr('Keyboard interrupt detected from the user. %s',
+                         'Exiting the node...')
+        if not rs.state().enabled:
+            self.send_position_cmd()
+
+    def send_position_cmd(self):
+        # send a message to put the robot back into position mode
+        position_mode = InteractionOptions()
+        position_mode.set_interaction_control_active(False)
+        self.pub.publish(position_mode.to_msg())
+        rospy.loginfo('Sending position command before shutdown')
+        rospy.sleep(0.5)
+
+
 def main():
     """
     Initiate constrained zero-G with a desired behavior from the current pose.
     The desired behavior can be specified by the optional arguments. By default,
     all directions will be set unconstrained when no options are provided.
     Note that the arm is not commanded to move but it will have the specified
-    interaction control behavior. If publish rate is 0 where the interaction
-    control command is only published once, after entering and exiting regular
-    zero-G, the arm will return to normal position mode. Also, regardless of
-    the publish rate, the regular zero-G behavior will not be affected by this.
+    interaction control behavior.
+
+    If publish the rate is 0, the interaction control command is only published
+    once; otherwise a last position command will be sent when the script exits.
+    For non-zero publishing rates, the arm will go back into constrained zero-G
+    if the arm's zero-g button is pressed and relased. Future motion commands
+    will use the interaction parameters set in the trajectory options.
 
     Call using:
     $ rosrun intera_examples constrained_zeroG.py  [arguments: see below]
@@ -76,6 +228,9 @@ def main():
 
     -r 20
     --> Set desired publish rate (Hz)
+
+    -r 0
+    --> The interaction command is published once, and the arm stays in that state
     """
 
     arg_fmt = argparse.RawDescriptionHelpFormatter
@@ -135,134 +290,14 @@ def main():
     parser.add_argument(
         "-r",  "--rate", type=int, default=10,
         help="A desired publish rate for updating interaction control commands (10Hz by default) -- 0 if we want to publish it only once")
+
     args = parser.parse_args(rospy.myargv()[1:])
 
-    try:
-        rospy.init_node('set_interaction_options_py')
-        pub = rospy.Publisher('/robot/limb/right/interaction_control_command', InteractionControlCommand, queue_size = 1)
-        rospy.sleep(0.5)
-
-        if args.rate > 0:
-            rate = rospy.Rate(args.rate)
-        elif args.rate == 0:
-            rospy.logwarn('Interaction control options will be set only once!')
-        elif args.rate < 0:
-            rospy.logerr('Invalid publish rate!')
-
-        # set the interaction control options in the current configuration
-        interaction_options = InteractionOptions()
-
-        # if one of the options is set
-        unconstrained_axes_default = [0, 0, 0, 0, 0, 0]
-        unconstrained_axes = unconstrained_axes_default
-
-        # create a list of the constrained zero G modes
-        sum_mode_list = sum(bool2int([args.position_only, args.orientation_only, args.plane_horizontal, args.plane_vertical_xz, args.plane_vertical_yz, args.nullspace_only]))
-
-        # create a list of the free axis options
-        free_axis_list = bool2int([args.position_x, args.position_y, args.position_z, args.orientation_x, args.orientation_y, args.orientation_z])
-        sum_free_axis_list = sum(free_axis_list)
-
-        zero_stiffness_axes = boolToggle(args.constrained_axes)
-        sum_zero_stiffness_axes = sum(zero_stiffness_axes)
-
-        if (sum_mode_list==0 and sum_zero_stiffness_axes==0 and sum_free_axis_list==0):
-            rospy.logerr('You need to either set one of the options or specify the desired axes of arbitrary movement! The movement of endpoint will be constrained in all directions!')
-
-        if (sum_mode_list>1 and sum_zero_stiffness_axes==0 and sum_free_axis_list==0):
-            rospy.logerr('You can set only one of the options among "pos_only", "ori_only", "plane_hor", and "plane_ver"! The movement of endpoint will be constrained in all directions!')
-
-        # give an error if the mode options as well as the individual axis options are set
-        if (sum_mode_list==1 and sum_zero_stiffness_axes==0 and sum_free_axis_list>0):
-            rospy.logerr('The individual axis options cannot be used together with the mode options! The movement of endpoint will be constrained in all directions!')
-
-        # give an error when the axes are specified by more than one method
-        if (sum_mode_list==0 and sum_zero_stiffness_axes>0 and sum_free_axis_list>0):
-            rospy.logerr('You can only set the axes either by an array or individual options! The movement of endpoint will be constrained in all directions!')
-
-        if (sum_mode_list==1 and sum_zero_stiffness_axes==0 and sum_free_axis_list>=0):
-            if args.position_only:
-                unconstrained_axes = [1, 1, 1, 0, 0, 0]
-            if args.orientation_only:
-                unconstrained_axes = [0, 0, 0, 1, 1, 1]
-            if args.plane_horizontal:
-                unconstrained_axes = [1, 1, 0, 0, 0, 0]
-            if args.plane_vertical_xz:
-                unconstrained_axes = [1, 0, 1, 0, 0, 0]
-            if args.plane_vertical_yz:
-                unconstrained_axes = [0, 1, 1, 0, 0, 0]
-            if args.nullspace_only:
-                unconstrained_axes = [0, 0, 0, 0, 0, 0]
-
-        # if the axes are specified by an array
-        if (sum_mode_list==0 and sum_zero_stiffness_axes>0 and sum_free_axis_list==0):
-            unconstrained_axes = zero_stiffness_axes
-
-        # if the axes are specified by individual options
-        if (sum_mode_list==0 and sum_zero_stiffness_axes==0 and sum_free_axis_list>0):
-            unconstrained_axes = free_axis_list
-
-        # set the stiffness to zero by default
-        interaction_options.set_K_impedance([0, 0, 0, 0, 0, 0])
-
-        # set the axes with maximum stiffness
-        interaction_options.set_max_impedance(boolToggle(int2bool(unconstrained_axes)))
-
-        interaction_options.set_in_endpoint_frame(args.in_endpoint_frame)
-
-        # set nullspace stiffness to zero if nullspace_only option is provided
-        if args.nullspace_only:
-            K_nullspace = [0, 0, 0, 0, 0, 0, 0]
-        else:
-            K_nullspace = args.K_nullspace
-
-        interaction_options.set_K_nullspace(K_nullspace)
-
-        if len(args.interaction_frame) < 7:
-            rospy.logerr('The number of elements must be 7!')
-        elif len(args.interaction_frame) == 7:
-            quat_sum_square = args.interaction_frame[3]*args.interaction_frame[3] + args.interaction_frame[4]*args.interaction_frame[4]
-            + args.interaction_frame[5]*args.interaction_frame[5] + args.interaction_frame[6]*args.interaction_frame[6]
-            if quat_sum_square  < 1.0 + 1e-7 and quat_sum_square > 1.0 - 1e-7:
-                interaction_frame = Pose()
-                interaction_frame.position.x = args.interaction_frame[0]
-                interaction_frame.position.y = args.interaction_frame[1]
-                interaction_frame.position.z = args.interaction_frame[2]
-                interaction_frame.orientation.w = args.interaction_frame[3]
-                interaction_frame.orientation.x = args.interaction_frame[4]
-                interaction_frame.orientation.y = args.interaction_frame[5]
-                interaction_frame.orientation.z = args.interaction_frame[6]
-                interaction_options.set_interaction_frame(interaction_frame)
-            else:
-                rospy.logerr('Invalid input to quaternion! The quaternion must be a unit quaternion!')
-        else:
-            rospy.logerr('Invalid input to interaction_frame!')
-
-        # always enable the rotations for constrained zero-G
-        interaction_options.set_rotations_for_constrained_zeroG(True)
-
-        msg = interaction_options.to_msg()
-
-        # print the resultant interaction options once
-        rospy.loginfo(msg)
-        pub.publish(msg)
-
-        rs = intera_interface.RobotEnable(CHECK_VERSION)
-        if args.rate > 0:
-            while not rospy.is_shutdown() and rs.state().enabled:
-                rate.sleep()
-                pub.publish(msg)
-
-    except rospy.ROSInterruptException:
-        rospy.logerr('Keyboard interrupt detected from the user. %s',
-                     'Exiting the node...')
-
-    if not rs.state().enabled:
-        # send a message to put the robot back into position mode
-        position_mode = InteractionOptions()
-        position_mode.set_interaction_control_active(False)
-        pub.publish(position_mode.to_msg())
-        rospy.sleep(0.5)
+    rospy.init_node('constrained_zeroG_py')
+    czg = ConstrainedZeroG(args)
+    if args.rate != 0:
+        rospy.on_shutdown(czg.send_position_cmd)
+    czg.send_msg()
 
 if __name__ == '__main__':
     main()

--- a/intera_examples/scripts/constrained_zeroG.py
+++ b/intera_examples/scripts/constrained_zeroG.py
@@ -235,13 +235,14 @@ def main():
 
     # always enable the rotations for constrained zero-G
     interaction_options.set_rotations_for_constrained_zeroG(True)
-
-    msg = interaction_options.to_msg()
+    # print the resultant interaction options once
+    rospy.loginfo(interaction_options.to_msg())
 
     ic_pub = InteractionPublisher()
+    rospy.sleep(0.5)
     if args.rate != 0:
         rospy.on_shutdown(ic_pub.send_position_mode_cmd)
-    ic_pub.send_command(msg, args.rate)
+    ic_pub.send_command(interaction_options, args.rate)
 
 
 if __name__ == '__main__':

--- a/intera_examples/scripts/constrained_zeroG.py
+++ b/intera_examples/scripts/constrained_zeroG.py
@@ -78,7 +78,8 @@ def main():
     --> Set desired publish rate (Hz)
 
     -r 0
-    --> The interaction command is published once, and the arm stays in that state
+    --> The interaction command is published once and exits. The arm can remain
+        in interaction control after this script.
     """
 
     arg_fmt = argparse.RawDescriptionHelpFormatter
@@ -137,10 +138,10 @@ def main():
         help="A list of desired nullspace stiffnesses, one for each of the 7 joints (a single value can be provided to apply the same value to all the directions) -- units are in (Nm/rad)")
     parser.add_argument(
         "-r",  "--rate", type=int, default=10,
-        help="A desired publish rate for updating interaction control commands (10Hz by default) -- 0 if we want to publish it only once")
+        help="A desired publish rate for updating interaction control commands (10Hz by default) -- a rate 0 publish once and exits which can cause the arm to remain in interaction control.")
 
     args = parser.parse_args(rospy.myargv()[1:])
-    rospy.init_node('constrained_zeroG_py')
+    rospy.init_node('constrained_zeroG')
 
     # set the interaction control options in the current configuration
     interaction_options = InteractionOptions()
@@ -235,6 +236,7 @@ def main():
 
     # always enable the rotations for constrained zero-G
     interaction_options.set_rotations_for_constrained_zeroG(True)
+
     # print the resultant interaction options once
     rospy.loginfo(interaction_options.to_msg())
 
@@ -243,6 +245,8 @@ def main():
     if args.rate != 0:
         rospy.on_shutdown(ic_pub.send_position_mode_cmd)
     ic_pub.send_command(interaction_options, args.rate)
+    if args.rate == 0:
+        rospy.sleep(0.5)
 
 
 if __name__ == '__main__':

--- a/intera_examples/scripts/set_interaction_options.py
+++ b/intera_examples/scripts/set_interaction_options.py
@@ -149,12 +149,14 @@ def main():
     interaction_options.set_disable_reference_resetting(args.disable_reference_resetting)
     interaction_options.set_rotations_for_constrained_zeroG(args.rotations_for_constrained_zeroG)
 
-    msg = interaction_options.to_msg()
+    # print the resultant interaction options once
+    rospy.loginfo(interaction_options.to_msg())
 
     ic_pub = InteractionPublisher()
+    rospy.sleep(0.5)
     if args.rate != 0:
         rospy.on_shutdown(ic_pub.send_position_mode_cmd)
-    ic_pub.send_command(msg, args.rate)
+    ic_pub.send_command(interaction_options, args.rate)
 
 
 if __name__ == '__main__':

--- a/intera_examples/scripts/set_interaction_options.py
+++ b/intera_examples/scripts/set_interaction_options.py
@@ -66,7 +66,8 @@ def main():
     --> Set desired publish rate (Hz)
 
     -r 0
-    --> The interaction command is published once, and the arm stays in that state
+    --> The interaction command is published once and exits. The arm can remain
+        in interaction control after this script.
     """
 
     arg_fmt = argparse.RawDescriptionHelpFormatter
@@ -116,10 +117,10 @@ def main():
         help="Allow arbitrary rotational displacements from the current orientation for constrained zero-G (works only with a stationary reference orientation)")
     parser.add_argument(
         "-r",  "--rate", type=int, default=10,
-        help="A desired publish rate for updating interaction control commands (10Hz by default) -- 0 if we want to publish it only once")
+        help="A desired publish rate for updating interaction control commands (10Hz by default) -- a rate 0 publish once and exits which can cause the arm to remain in interaction control.")
 
     args = parser.parse_args(rospy.myargv()[1:])
-    rospy.init_node('set_interaction_options_py')
+    rospy.init_node('set_interaction_options')
 
     # set the interaction control options in the current configuration
     interaction_options = InteractionOptions()
@@ -157,6 +158,8 @@ def main():
     if args.rate != 0:
         rospy.on_shutdown(ic_pub.send_position_mode_cmd)
     ic_pub.send_command(interaction_options, args.rate)
+    if args.rate == 0:
+        rospy.sleep(0.5)
 
 
 if __name__ == '__main__':

--- a/intera_examples/scripts/set_interaction_options.py
+++ b/intera_examples/scripts/set_interaction_options.py
@@ -15,96 +15,11 @@
 # limitations under the License.
 
 import rospy
-from intera_core_msgs.msg import InteractionControlCommand
 import argparse
 from geometry_msgs.msg import Pose
-from intera_motion_interface import InteractionOptions
+from intera_core_msgs.msg import InteractionControlCommand
+from intera_motion_interface import (InteractionOptions, InteractionPublisher)
 from intera_motion_interface.utility_functions import int2bool
-
-import intera_interface
-from intera_interface import CHECK_VERSION
-
-class SetInteractionOptions(object):
-    """
-    Send Interaction Options to robot
-    """
-
-    def __init__(self, args):
-        self.pub = rospy.Publisher('/robot/limb/right/interaction_control_command',
-                                  InteractionControlCommand, queue_size = 1)
-        rospy.sleep(0.5)
-
-        self.repeat = False
-        if args.rate > 0:
-            self.rate = rospy.Rate(args.rate)
-            self.repeat = True
-        elif args.rate == 0:
-            rospy.logwarn('Interaction control options will be set only once!')
-        elif args.rate < 0:
-            rospy.logerr('Invalid publish rate!')
-
-        # set the interaction control options in the current configuration
-        interaction_options = InteractionOptions()
-
-        interaction_options.set_interaction_control_active(int2bool(args.interaction_active))
-        interaction_options.set_K_impedance(args.K_impedance)
-        interaction_options.set_max_impedance(int2bool(args.max_impedance))
-        interaction_options.set_interaction_control_mode(args.interaction_control_mode)
-        interaction_options.set_in_endpoint_frame(args.in_endpoint_frame)
-        interaction_options.set_force_command(args.force_command)
-        interaction_options.set_K_nullspace(args.K_nullspace)
-        if len(args.interaction_frame) < 7:
-            rospy.logerr('The number of elements must be 7!')
-        elif len(args.interaction_frame) == 7:
-            quat_sum_square = (args.interaction_frame[3]*args.interaction_frame[3]
-                              + args.interaction_frame[4]*args.interaction_frame[4]
-                              + args.interaction_frame[5]*args.interaction_frame[5]
-                              + args.interaction_frame[6]*args.interaction_frame[6])
-            if quat_sum_square  < 1.0 + 1e-7 and quat_sum_square > 1.0 - 1e-7:
-                interaction_frame = Pose()
-                interaction_frame.position.x = args.interaction_frame[0]
-                interaction_frame.position.y = args.interaction_frame[1]
-                interaction_frame.position.z = args.interaction_frame[2]
-                interaction_frame.orientation.w = args.interaction_frame[3]
-                interaction_frame.orientation.x = args.interaction_frame[4]
-                interaction_frame.orientation.y = args.interaction_frame[5]
-                interaction_frame.orientation.z = args.interaction_frame[6]
-                interaction_options.set_interaction_frame(interaction_frame)
-            else:
-                rospy.logerr('Invalid input to quaternion! The quaternion must be a unit quaternion!')
-        else:
-            rospy.logerr('Invalid input to interaction_frame!')
-
-        interaction_options.set_disable_damping_in_force_control(args.disable_damping_in_force_control)
-        interaction_options.set_disable_reference_resetting(args.disable_reference_resetting)
-        interaction_options.set_rotations_for_constrained_zeroG(args.rotations_for_constrained_zeroG)
-
-        self.msg = interaction_options.to_msg()
-
-    def send_msg(self):
-        try:
-            # print the resultant interaction options once
-            rospy.loginfo(self.msg)
-            self.pub.publish(self.msg)
-            rs = intera_interface.RobotEnable(CHECK_VERSION)
-            if self.repeat:
-                while not rospy.is_shutdown() and rs.state().enabled:
-                    self.rate.sleep()
-                    self.pub.publish(self.msg)
-        except rospy.ROSInterruptException:
-            rospy.logerr('Keyboard interrupt detected from the user. %s',
-                         'Exiting the node...')
-        if not rs.state().enabled:
-            self.send_position_cmd()
-
-    def send_position_cmd(self):
-        # send a message to put the robot back into position mode
-        position_mode = InteractionOptions()
-        position_mode.set_interaction_control_active(False)
-        self.pub.publish(position_mode.to_msg())
-        rospy.loginfo('Sending position command before shutdown')
-        rospy.sleep(0.5)
-
 
 def main():
     """
@@ -204,12 +119,43 @@ def main():
         help="A desired publish rate for updating interaction control commands (10Hz by default) -- 0 if we want to publish it only once")
 
     args = parser.parse_args(rospy.myargv()[1:])
-
     rospy.init_node('set_interaction_options_py')
-    setIC = SetInteractionOptions(args)
+
+    # set the interaction control options in the current configuration
+    interaction_options = InteractionOptions()
+
+    interaction_options.set_interaction_control_active(int2bool(args.interaction_active))
+    interaction_options.set_K_impedance(args.K_impedance)
+    interaction_options.set_max_impedance(int2bool(args.max_impedance))
+    interaction_options.set_interaction_control_mode(args.interaction_control_mode)
+    interaction_options.set_in_endpoint_frame(args.in_endpoint_frame)
+    interaction_options.set_force_command(args.force_command)
+    interaction_options.set_K_nullspace(args.K_nullspace)
+
+    if len(args.interaction_frame) == 7:
+        interaction_frame = Pose()
+        interaction_frame.position.x = args.interaction_frame[0]
+        interaction_frame.position.y = args.interaction_frame[1]
+        interaction_frame.position.z = args.interaction_frame[2]
+        interaction_frame.orientation.w = args.interaction_frame[3]
+        interaction_frame.orientation.x = args.interaction_frame[4]
+        interaction_frame.orientation.y = args.interaction_frame[5]
+        interaction_frame.orientation.z = args.interaction_frame[6]
+        interaction_options.set_interaction_frame(interaction_frame)
+    else:
+        rospy.logerr('Invalid input to interaction_frame. Must be 7 elements.')
+
+    interaction_options.set_disable_damping_in_force_control(args.disable_damping_in_force_control)
+    interaction_options.set_disable_reference_resetting(args.disable_reference_resetting)
+    interaction_options.set_rotations_for_constrained_zeroG(args.rotations_for_constrained_zeroG)
+
+    msg = interaction_options.to_msg()
+
+    ic_pub = InteractionPublisher()
     if args.rate != 0:
-        rospy.on_shutdown(setIC.send_position_cmd)
-    setIC.send_msg()
+        rospy.on_shutdown(ic_pub.send_position_mode_cmd)
+    ic_pub.send_command(msg, args.rate)
+
 
 if __name__ == '__main__':
     main()

--- a/intera_interface/src/intera_motion_interface/__init__.py
+++ b/intera_interface/src/intera_motion_interface/__init__.py
@@ -3,6 +3,7 @@ from .motion_trajectory import MotionTrajectory
 from .motion_waypoint import MotionWaypoint
 from .motion_waypoint_options import MotionWaypointOptions
 from .interaction_options import InteractionOptions
+from .interaction_publisher import InteractionPublisher
 from .random_walk import RandomWalk
 from .utility_functions import (
     clamp_float_warn,

--- a/intera_interface/src/intera_motion_interface/interaction_options.py
+++ b/intera_interface/src/intera_motion_interface/interaction_options.py
@@ -178,10 +178,20 @@ class InteractionOptions(object):
           - None:  populate with vector of default values
           - Pose: copy all the elements
         """
-        if isinstance(interaction_frame, Pose):
-            self._data.interaction_frame = interaction_frame
-        else:
+        if not isinstance(interaction_frame, Pose):
             rospy.logerr('interaction_frame must be of type geometry_msgs.Pose')
+            return
+
+        # check for unit quaternion
+        quat_sum_square = (interaction_frame.orientation.w * interaction_frame.orientation.w
+                          + interaction_frame.orientation.x * interaction_frame.orientation.x
+                          + interaction_frame.orientation.y * interaction_frame.orientation.y
+                          + interaction_frame.orientation.z * interaction_frame.orientation.z)
+        if quat_sum_square  > 1.0 + 1e-7 or quat_sum_square < 1.0 - 1e-7:
+            rospy.logerr('Invalid input to quaternion! The quaternion must be a unit quaternion!')
+            return
+
+        self._data.interaction_frame = interaction_frame
 
     def set_endpoint_name(self, endpoint_name = default_endpoint_name):
         """

--- a/intera_interface/src/intera_motion_interface/interaction_publisher.py
+++ b/intera_interface/src/intera_motion_interface/interaction_publisher.py
@@ -23,15 +23,30 @@ from intera_interface import CHECK_VERSION
 
 class InteractionPublisher(object):
     """
-    Send Interaction Commands to robot
+    ROS publisher for sending command messages to robot
     """
 
     def __init__(self):
+        """
+        Constructor - creates a publisher for interaction_control_command
+        Note, that the program may need to sleep for 0.5 seconds before the
+        publisher is established.
+        """
         self.pub = rospy.Publisher('/robot/limb/right/interaction_control_command',
-                                  InteractionControlCommand, queue_size = 1)
-        rospy.sleep(0.5)
+                                   InteractionControlCommand, queue_size=1,
+                                   tcp_nodelay=True)
+        self.enable = intera_interface.RobotEnable(CHECK_VERSION)
 
     def send_command(self, msg, pub_rate):
+        """
+        @param msg: either an InteractionControlCommand message or
+                    InteractionOptions object to be published
+        @param pub_rate: the rate in Hz to publish the command
+
+        Note that this function is blocking for non-zero pub_rates until
+        the node is shutdown (e.g. via cntl+c) or the robot is disabled.
+        A pub_rate of zero will publish the function once and return.
+        """
         repeat = False
         if pub_rate > 0:
             rate = rospy.Rate(pub_rate)
@@ -41,22 +56,24 @@ class InteractionPublisher(object):
         elif pub_rate < 0:
             rospy.logerr('Invalid publish rate!')
 
+        if isinstance(msg, InteractionOptions):
+            msg = msg.to_msg()
+
         try:
-            # print the resultant interaction options once
-            rospy.loginfo(msg)
             self.pub.publish(msg)
-            rs = intera_interface.RobotEnable(CHECK_VERSION)
-            while repeat and not rospy.is_shutdown() and rs.state().enabled:
+            while repeat and not rospy.is_shutdown() and self.enable.state().enabled:
                 rate.sleep()
                 self.pub.publish(msg)
         except rospy.ROSInterruptException:
             rospy.logerr('Keyboard interrupt detected from the user. %s',
                          'Exiting the node...')
-        if not rs.state().enabled:
+        if not self.enable.state().enabled:
             self.send_position_mode_cmd()
 
     def send_position_mode_cmd(self):
-        # send a message to put the robot back into position mode
+        '''
+        Send a message to put the robot back into position mode
+        '''
         position_mode = InteractionOptions()
         position_mode.set_interaction_control_active(False)
         self.pub.publish(position_mode.to_msg())

--- a/intera_interface/src/intera_motion_interface/interaction_publisher.py
+++ b/intera_interface/src/intera_motion_interface/interaction_publisher.py
@@ -51,8 +51,6 @@ class InteractionPublisher(object):
         if pub_rate > 0:
             rate = rospy.Rate(pub_rate)
             repeat = True
-        elif pub_rate == 0:
-            rospy.logwarn('Interaction control options will be set only once!')
         elif pub_rate < 0:
             rospy.logerr('Invalid publish rate!')
 
@@ -67,8 +65,9 @@ class InteractionPublisher(object):
         except rospy.ROSInterruptException:
             rospy.logerr('Keyboard interrupt detected from the user. %s',
                          'Exiting the node...')
-        if not self.enable.state().enabled:
-            self.send_position_mode_cmd()
+        finally:
+            if repeat:
+                self.send_position_mode_cmd()
 
     def send_position_mode_cmd(self):
         '''

--- a/intera_interface/src/intera_motion_interface/interaction_publisher.py
+++ b/intera_interface/src/intera_motion_interface/interaction_publisher.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python
+
+# Copyright (c) 2018, Rethink Robotics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import rospy
+from intera_core_msgs.msg import InteractionControlCommand
+from interaction_options import InteractionOptions
+import intera_interface
+from intera_interface import CHECK_VERSION
+
+class InteractionPublisher(object):
+    """
+    Send Interaction Commands to robot
+    """
+
+    def __init__(self):
+        self.pub = rospy.Publisher('/robot/limb/right/interaction_control_command',
+                                  InteractionControlCommand, queue_size = 1)
+        rospy.sleep(0.5)
+
+    def send_command(self, msg, pub_rate):
+        repeat = False
+        if pub_rate > 0:
+            rate = rospy.Rate(pub_rate)
+            repeat = True
+        elif pub_rate == 0:
+            rospy.logwarn('Interaction control options will be set only once!')
+        elif pub_rate < 0:
+            rospy.logerr('Invalid publish rate!')
+
+        try:
+            # print the resultant interaction options once
+            rospy.loginfo(msg)
+            self.pub.publish(msg)
+            rs = intera_interface.RobotEnable(CHECK_VERSION)
+            while repeat and not rospy.is_shutdown() and rs.state().enabled:
+                rate.sleep()
+                self.pub.publish(msg)
+        except rospy.ROSInterruptException:
+            rospy.logerr('Keyboard interrupt detected from the user. %s',
+                         'Exiting the node...')
+        if not rs.state().enabled:
+            self.send_position_mode_cmd()
+
+    def send_position_mode_cmd(self):
+        # send a message to put the robot back into position mode
+        position_mode = InteractionOptions()
+        position_mode.set_interaction_control_active(False)
+        self.pub.publish(position_mode.to_msg())
+        rospy.loginfo('Sending position command')
+        rospy.sleep(0.5)


### PR DESCRIPTION
For these two scripts, I moved most of the code out of the main function into a object class with a send_position_cmd function which is called at shutdown. Setting the publishing rate to zero will the send the interaction command once and exit without sending a position command.

Tested on a robot by stopping the two scripts by pressing both cntr-c and the e-stop button. Tested that commanded line arguments are still properly passed into the interaction command messages.