### PR TITLE
send_random_trajectory.py option to set RNG seed

### DIFF
--- a/intera_examples/scripts/send_random_trajectory.py
+++ b/intera_examples/scripts/send_random_trajectory.py
@@ -57,6 +57,12 @@ def main():
     -o ~/Desktop/fileName.bag
     --> Save the trajectory message to a bag file
 
+    --seed 1234
+    --> Set the seed in the random number generator before constructing the
+        trajectory. This allows for repeatable motion and is useful for
+        writing repeatable tests that use this script. Note: for a repeatable
+        test the starting pose of the robot must also be the same each time.
+
     -p
     --> Prints the trajectory to terminal before sending
 
@@ -101,6 +107,9 @@ def main():
     parser.add_argument(
         "--timeout", type=float, default=None,
         help="Max time in seconds to complete motion goal before returning. None is interpreted as an infinite timeout.")
+    parser.add_argument(
+        "--rng_seed", type=int, default=0,
+        help="specify a seed to pass to the random number generator. Set to zero to use default initialization.")
     args = parser.parse_args()
 
     if args.waypoint_count < 1:
@@ -134,7 +143,7 @@ def main():
         traj.append_waypoint(waypoint.to_msg())
 
         # Set up the random walk generator
-        walk = RandomWalk()
+        walk = RandomWalk(seed=args.rng_seed)
         limits = JointLimits()
         walk.set_lower_limits(limits.get_joint_lower_limits(limb.joint_names()))
         walk.set_upper_limits(limits.get_joint_upper_limits(limb.joint_names()))

--- a/intera_interface/src/intera_motion_interface/random_walk.py
+++ b/intera_interface/src/intera_motion_interface/random_walk.py
@@ -24,7 +24,7 @@ class RandomWalk(object):
     This class is used to create a random walk in a bounded state space
     """
 
-    def __init__(self):
+    def __init__(self, seed = 0):
         """
         Constructor - creates an empty random walk object.
         Be sure to set the lower limits, upper limits, and past point before
@@ -37,6 +37,8 @@ class RandomWalk(object):
         self._dimension = None
         self._boundary_padding = 0.0
         self._maximum_distance = 1.0
+        if seed > 0:
+            random.seed(seed)
 
     def set_lower_limits(self, low):
         """


### PR DESCRIPTION
This commit adds an option to the send_random_trajectory script
so that the user can optionally set the RNG seed. This allows
for the script to be called in a repeatable fashion. If the
argument is ommitted, then the default initialization of the
random number generator is used.