### PR TITLE
Fix send_urdf_fragment.py for ROS > Indigo (#140)

### DIFF
--- a/intera_interface/scripts/send_urdf_fragment.py
+++ b/intera_interface/scripts/send_urdf_fragment.py
@@ -19,15 +19,19 @@ import sys
 import argparse
 
 import rospy
-import xacro_jade
+try:
+    import xacro_jade as xacro
+except ImportError:
+    import xacro
+
 
 from intera_core_msgs.msg import (
     URDFConfiguration,
 )
 
 def xacro_parse(filename):
-    doc = xacro_jade.parse(None, filename)
-    xacro_jade.process_doc(doc, in_order=True)
+    doc = xacro.parse(None, filename)
+    xacro.process_doc(doc, in_order=True)
     return doc.toprettyxml(indent='  ')
 
 def send_urdf(parent_link, root_joint, urdf_filename, duration):


### PR DESCRIPTION
xacro_jade is present only in ROS Indigo as it is a backport of xacro from Jade
(cherry picked from commit 2b34620df9c295a6c9e821d95289a38a6f04305b)